### PR TITLE
Actor duration. Close #9.

### DIFF
--- a/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -18,7 +18,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect {
 
         long start = System.nanoTime();
         Object result = proceed(actorCell, msg);
-        long duration = System.nanoTime() - start;
+        long duration = (System.nanoTime() - start) / 1000000;     // ms
 
         // record the actor duration
         counterInterface.recordGaugeValue("akka.actor.duration", (int)duration, tags);

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellCounterTest.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellCounterTest.scala
@@ -17,9 +17,9 @@ class ActorCellCounterTest extends TestKit(ActorSystem()) with SpecificationLike
   sequential
 
   "Monitoring" should {
-    val messageIntegerAspect = "message.Integer"
-    val messageStringAspect  = "message.String"
-    val queueSizeAspect      = "queue.size"
+    val messageIntegerAspect = "akka.message.Integer"
+    val messageStringAspect  = "akka.message.String"
+    val queueSizeAspect      = "akka.queue.size"
 
     // records the count of messages received, grouped by message type
     "Record the message sent to actor" in {

--- a/example-akka/src/main/scala/org/eigengo/monitor/example/akka/Main.scala
+++ b/example-akka/src/main/scala/org/eigengo/monitor/example/akka/Main.scala
@@ -1,6 +1,7 @@
 package org.eigengo.monitor.example.akka
 
 import akka.actor.{ActorRef, Props, ActorSystem, Actor}
+import akka.routing.RoundRobinRouter
 
 // run with -javaagent:$HOME/.m2/repository/org/aspectj/aspectjweaver/1.7.3/aspectjweaver-1.7.3.jar
 // in my case -javaagent:/Users/janmachacek/.m2/repository/org/aspectj/aspectjweaver/1.7.3/aspectjweaver-1.7.3.jar
@@ -29,7 +30,7 @@ object Main extends App {
   }
 
   val system = ActorSystem()
-  val bar = system.actorOf(Props[BarActor], "bar")
+  val bar = system.actorOf(Props[BarActor].withRouter(RoundRobinRouter(nrOfInstances = 10)), "bar")
   val foo = system.actorOf(Props(new FooActor(bar)), "foo")
   val CountPattern = "(\\d+)".r
 


### PR DESCRIPTION
Measures the duration of normal execution of the `receive` method. Publishes as `akka.actor.duration`, tagged with the actor path.
