### PR TITLE
Improve tagging of routed actors

### DIFF
--- a/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/AbstractMonitoringAspect.aj
+++ b/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/AbstractMonitoringAspect.aj
@@ -6,15 +6,22 @@ import org.eigengo.monitor.output.CounterInterface;
 import org.eigengo.monitor.output.NullCounterInterface;
 
 abstract aspect AbstractMonitoringAspect {
+    // if true, the monitoring will include the /system actors
+    protected boolean includeSystemActors = false;
+    // if true, the monitoring will include the child actors created as routees
+    protected boolean includeRoutees = true;
+
     private static String agentName = "akka";
     protected static final CounterInterface counterInterface = createCounterInterface();
 
-    private static CounterInterface createCounterInterface() throws ClassCastException{
+    private static CounterInterface createCounterInterface() {
         try {
             AgentConfiguration configuration = AgentConfigurationFactory.getAgentConfiguration(agentName);
             CounterInterface counterInterface = (CounterInterface)Class.forName(configuration.counterInterfaceClassName()).newInstance();
             return counterInterface;
         } catch (final ReflectiveOperationException e) {
+            return new NullCounterInterface();
+        } catch (final ClassCastException e) {
             return new NullCounterInterface();
         }
     }

--- a/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -3,26 +3,46 @@ package org.eigengo.monitor.agent.akka;
 import akka.actor.ActorCell;
 
 public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect {
+    private boolean includeSystemActors = false;
 
-    Object around(ActorCell actorCell, Object msg): org.eigengo.monitor.agent.akka.Pointcuts.receiveMessage(actorCell, msg) {
-        // we tag by actor name
-        String[] tags = new String[] {
+    // decide whether to include this ActorCell in our measurements
+    private boolean includeActorCell(ActorCell actorCell) {
+        if (this.includeSystemActors) return true;
+
+        String userOrSystem = actorCell.self().path().getElements().iterator().next();
+        return "user".equals(userOrSystem);
+    }
+
+    // get the tags for the cell
+    private String[] getTags(ActorCell actorCell) {
+
+        return new String[] {
                 actorCell.self().path().toString()
         };
+    }
+
+    Object around(ActorCell actorCell, Object msg): org.eigengo.monitor.agent.akka.Pointcuts.receiveMessage(actorCell, msg) {
+        if (!includeActorCell(actorCell)) return proceed(actorCell, msg);
+
+        // we tag by actor name
+        String[] tags = getTags(actorCell);
 
         // record the queue size
         counterInterface.recordGaugeValue("akka.queue.size", actorCell.numberOfMessages(), tags);
-
         // record the message
         counterInterface.incrementCounter("akka.message." + msg.getClass().getSimpleName(), tags);
 
+        // measure the time. we're using the ``nanoTime`` call to access the high-precision timer.
+        // since we're not really interested in wall time, but just some increasing measure of
+        // elapsed time
         long start = System.nanoTime();
-        Object result = proceed(actorCell, msg);
-        long duration = (System.nanoTime() - start) / 1000000;     // ms
+        Object result = proceed(actorCell, msg);                   // result will always be ``null``.
+        long duration = (System.nanoTime() - start) / 1000000;     // ns or µs is too fine. ms will do for now.
 
         // record the actor duration
         counterInterface.recordGaugeValue("akka.actor.duration", (int)duration, tags);
 
+        // return null would do the trick, but we want to be _proper_.
         return result;
     }
 

--- a/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -1,9 +1,12 @@
 package org.eigengo.monitor.agent.akka;
 
 import akka.actor.ActorCell;
+import akka.actor.ActorPath;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect {
-    private boolean includeSystemActors = false;
 
     // decide whether to include this ActorCell in our measurements
     private boolean includeActorCell(ActorCell actorCell) {
@@ -15,10 +18,22 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect {
 
     // get the tags for the cell
     private String[] getTags(ActorCell actorCell) {
+        List<String> tags = new ArrayList<String>();
 
-        return new String[] {
-                actorCell.self().path().toString()
-        };
+        final ActorPath actorPath = actorCell.self().path();
+
+        // TODO: Improve detection of routed actors. This relies only on the naming :(.
+        String lastPathElement = actorPath.elements().last();
+        if (lastPathElement.startsWith("$")) {
+            // this is routed actor.
+            tags.add(actorPath.parent().toString());
+            if (this.includeRoutees) tags.add(actorPath.toString());
+        } else {
+            // there is no supervisor
+            tags.add(actorPath.toString());
+        }
+
+        return tags.toArray(new String[tags.size()]);
     }
 
     Object around(ActorCell actorCell, Object msg): org.eigengo.monitor.agent.akka.Pointcuts.receiveMessage(actorCell, msg) {

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellCounterTest.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellCounterTest.scala
@@ -57,7 +57,7 @@ class ActorCellCounterTest extends TestKit(ActorSystem()) with SpecificationLike
       Thread.sleep(count * (10 + 2))
 
       // fold by _max_ over the counters by the ``queueSizeAspect``, tagged with this actor's name
-      val counter = TestCounterInterface.foldlByAspect(queueSizeAspect, SingleTag(tag))(TestCounter.max)(0)
+      val counter = TestCounterInterface.foldlByAspect(queueSizeAspect, ExactTag(tag))(TestCounter.max)(0)
       counter.value must beGreaterThan(count - tolerance)
       counter.tags must containAllOf(List(tag))
     }
@@ -72,7 +72,7 @@ class ActorCellCounterTest extends TestKit(ActorSystem()) with SpecificationLike
 
       Thread.sleep(1100)
 
-      val counter = TestCounterInterface.foldlByAspect(actorDurationAspect, SingleTag(tag))(TestCounter.max)(0)
+      val counter = TestCounterInterface.foldlByAspect(actorDurationAspect, ExactTag(tag))(TestCounter.max)(0)
       counter.value must beGreaterThan(900)
       counter.value must beLessThan(1100)
       counter.tags must containAllOf(List(tag))
@@ -98,11 +98,11 @@ class ActorCellCounterTest extends TestKit(ActorSystem()) with SpecificationLike
       Thread.sleep(2000)
 
       // we expect to see 10 integers for the supervisor and 1 integer for each child
-      val supCounter = TestCounterInterface.foldlByAspect(messageIntegerAspect, SingleTag(tag))(TestCounter.plus)(0)
-      val c1Counter  = TestCounterInterface.foldlByAspect(messageIntegerAspect, SingleTag(tag + "/_a"))(TestCounter.plus)(0)
+      val supCounter = TestCounterInterface.foldlByAspect(messageIntegerAspect, ContainsTag(tag))(TestCounter.plus)(0)
+      val c1Counter  = TestCounterInterface.foldlByAspect(messageIntegerAspect, ExactTag(tag + "/$a"))(TestCounter.plus)(0)
 
       supCounter.value mustEqual 10
-      c1Counter.value mustEqual 10
+      c1Counter.value mustEqual 1
     }
   }
 

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellCounterTest.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellCounterTest.scala
@@ -5,22 +5,27 @@ import akka.actor.{Props, ActorSystem}
 import akka.testkit.{TestActorRef, TestKit}
 import org.specs2.runner.JUnitRunner
 import org.junit.runner.RunWith
+import akka.routing.RoundRobinRouter
 
 /**
  * Checks that the ``ActorCellMonitoringAspect`` records the required information.
  *
  * Here, we check that we can successfully record the message counts, and that we can
  * monitor the queue size.
+ *
+ * When running from your IDE, remember to include the -javaagent JVM parameter:
+ * -javaagent:$HOME/.m2/repository/org/aspectj/aspectjweaver/1.7.3/aspectjweaver-1.7.3.jar
+ * in my case -javaagent:/Users/janmachacek/.m2/repository/org/aspectj/aspectjweaver/1.7.3/aspectjweaver-1.7.3.jar
  */
 @RunWith(classOf[JUnitRunner])
 class ActorCellCounterTest extends TestKit(ActorSystem()) with SpecificationLike {
   sequential
+  val messageIntegerAspect = "akka.message.Integer"
+  val messageStringAspect  = "akka.message.String"
+  val queueSizeAspect      = "akka.queue.size"
+  val actorDurationAspect  = "akka.actor.duration"
 
-  "Monitoring" should {
-    val messageIntegerAspect = "akka.message.Integer"
-    val messageStringAspect  = "akka.message.String"
-    val queueSizeAspect      = "akka.queue.size"
-    val actorDurationAspect  = "akka.actor.duration"
+  "Non-routed actor monitoring" should {
 
     // records the count of messages received, grouped by message type
     "Record the message sent to actor" in {
@@ -57,6 +62,7 @@ class ActorCellCounterTest extends TestKit(ActorSystem()) with SpecificationLike
       counter.tags must containAllOf(List(tag))
     }
 
+    // keep track of the actor duration; that is the time the receive method takes
     "Record the actor duration" in {
       val actorName = "dur"
       val tag = s"akka://default/user/$actorName"
@@ -72,6 +78,32 @@ class ActorCellCounterTest extends TestKit(ActorSystem()) with SpecificationLike
       counter.tags must containAllOf(List(tag))
     }
 
+  }
+
+  // If we create actor "foo" with round-robin routing with x | x > 1 instances, then each instance's metrics
+  // should _also_ be contributed to the supervisor
+  //
+  // Nota bene the _also_ bit: we record the metrics for each instance _and_ add them to the parent. Put more
+  // plainly, the tags for routed actors should include the actor itself and its supervisor
+  "Routed actor monitoring" should {
+
+    "Record the message sent to actor" in {
+      val actorName = "routedFoo"
+      val tag = s"akka://default/user/$actorName"
+      val count = 10
+      val simpleActor = system.actorOf(Props[SimpleActor].withRouter(RoundRobinRouter(nrOfInstances = count)), actorName)
+
+      for (i <- 0 until count) simpleActor ! 100
+
+      Thread.sleep(2000)
+
+      // we expect to see 10 integers for the supervisor and 1 integer for each child
+      val supCounter = TestCounterInterface.foldlByAspect(messageIntegerAspect, SingleTag(tag))(TestCounter.plus)(0)
+      val c1Counter  = TestCounterInterface.foldlByAspect(messageIntegerAspect, SingleTag(tag + "/_a"))(TestCounter.plus)(0)
+
+      supCounter.value mustEqual 10
+      c1Counter.value mustEqual 10
+    }
   }
 
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/TestCounterInterface.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/TestCounterInterface.scala
@@ -68,8 +68,8 @@ object TestCounter {
  */
 sealed trait TagFilter
 case object AnyTag extends TagFilter
-case class SingleTag(tag: String) extends TagFilter
-// case class AllTags(tags: List[String]) extends TagFilter
+case class ExactTag(tag: String) extends TagFilter
+case class ContainsTag(tag: String) extends TagFilter
 
 /**
  * Companion for the TestCounterInterface containing all recorded events
@@ -106,8 +106,9 @@ object TestCounterInterface {
     def pred(x: TestCounter): Boolean =
       (x.aspect == aspect) &&
       (tagFilter match {
-        case AnyTag         => true
-        case SingleTag(tag) => x.tags.size == 1 && x.tags.head == tag
+        case AnyTag           => true
+        case ExactTag(tag)    => x.tags.size == 1 && x.tags.head == tag
+        case ContainsTag(tag) => x.tags.contains(tag)
       })
 
     counters.foldLeft[List[TestCounter]](Nil) { (b, a) =>


### PR DESCRIPTION
When encountering a routed actor, the monitoring tags the appropriate counters and gauges with tags that identify the routee as well as the supervisor.

By setting `protected boolean includeRoutees = false;` in `AbstractMonitoringAspect`, you can only include the supervisor; in effect aggregating over the routed children.

Close #15 
