### PR TITLE
Actor error rate

### DIFF
--- a/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -36,26 +36,41 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect {
         return tags.toArray(new String[tags.size()]);
     }
 
-    Object around(ActorCell actorCell, Object msg): org.eigengo.monitor.agent.akka.Pointcuts.receiveMessage(actorCell, msg) {
+    Object around(ActorCell actorCell, Object msg) throws Throwable : org.eigengo.monitor.agent.akka.Pointcuts.receiveMessage(actorCell, msg) {
         if (!includeActorCell(actorCell)) return proceed(actorCell, msg);
 
         // we tag by actor name
-        String[] tags = getTags(actorCell);
+        final String[] tags = getTags(actorCell);
 
         // record the queue size
         counterInterface.recordGaugeValue("akka.queue.size", actorCell.numberOfMessages(), tags);
-        // record the message
+        // record the message, general and specific
+        counterInterface.incrementCounter("akka.message", tags);
         counterInterface.incrementCounter("akka.message." + msg.getClass().getSimpleName(), tags);
 
         // measure the time. we're using the ``nanoTime`` call to access the high-precision timer.
         // since we're not really interested in wall time, but just some increasing measure of
         // elapsed time
-        long start = System.nanoTime();
-        Object result = proceed(actorCell, msg);                   // result will always be ``null``.
-        long duration = (System.nanoTime() - start) / 1000000;     // ns or µs is too fine. ms will do for now.
+        Object result = null;
+        // non-null error means that the target has hard-failed
+        Throwable error = null;
+        final long start = System.nanoTime();
+        try {
+            // result will always be ``null``, because target returns ``Unit``
+            result = proceed(actorCell, msg);
+        } catch (final Throwable t) {
+            // record the error, general and specific
+            counterInterface.incrementCounter("akka.actor.error", tags);
+            counterInterface.incrementCounter(String.format("akka.actor.error.%s", t.getMessage()), tags);
+            error = t;
+        }
+        // ns or µs is too fine. ms will do for now.
+        final long duration = (System.nanoTime() - start) / 1000000;
 
         // record the actor duration
-        counterInterface.recordGaugeValue("akka.actor.duration", (int)duration, tags);
+        counterInterface.recordExecutionTime("akka.actor.duration", (int)duration, tags);
+
+        if (error != null) throw error;
 
         // return null would do the trick, but we want to be _proper_.
         return result;

--- a/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -6,4 +6,5 @@ abstract aspect Pointcuts {
     static pointcut receiveMessage(ActorCell actorCell, Object msg) : target(actorCell) &&
             call(* akka.actor.ActorCell.receiveMessage(..)) && args(msg);
 
+    // static pointcut handleError(ActorCell actorCell)
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/SimpleActor.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/SimpleActor.scala
@@ -10,6 +10,8 @@ class SimpleActor extends Actor {
     case i: Int =>
       // for speed testing
       Thread.sleep(i)
+    case false =>
+      throw new RuntimeException("Bantha poodoo!")
   }
 
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/TestCounterInterface.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/TestCounterInterface.scala
@@ -10,16 +10,16 @@ import scala.collection.mutable
  */
 class TestCounterInterface extends CounterInterface {
 
-  override def decrementCounter(name: String, tags: String*): Unit = {
-    TestCounterInterface.add(name, -1, tags.toList)
-  }
-
   override def incrementCounter(name: String, tags: String*): Unit = {
     TestCounterInterface.add(name, 1, tags.toList)
   }
 
   override def recordGaugeValue(aspect: String, value: Int, tags: String*): Unit = {
     TestCounterInterface.set(aspect, value, tags.toList)
+  }
+
+  override def recordExecutionTime(aspect: String, duration: Int, tags: String*): Unit = {
+    TestCounterInterface.set(aspect, duration, tags.toList)
   }
 }
 

--- a/output-api/src/main/java/org/eigengo/monitor/output/CounterInterface.java
+++ b/output-api/src/main/java/org/eigengo/monitor/output/CounterInterface.java
@@ -16,14 +16,6 @@ public interface CounterInterface {
     void incrementCounter(String aspect, String... tags);
 
     /**
-     * Decrement the counter identified by {@code aspect} by one.
-     *
-     * @param aspect the aspect to increment
-     * @param tags optional tags
-     */
-    void decrementCounter(String aspect, String... tags);
-
-    /**
      * Records gauge {@code value} for the given {@code aspect}, with optional {@code tags}
      *
      * @param aspect the aspect to record the value for
@@ -32,4 +24,12 @@ public interface CounterInterface {
      */
     void recordGaugeValue(String aspect, int value, String... tags);
 
+    /**
+     * Records the execution time of the given {@code aspect}, with optional {@code tags}
+     *
+     * @param aspect the aspect to record the execution time for
+     * @param duration the execution time (most likely in ms)
+     * @param tags optional tags
+     */
+    void recordExecutionTime(String aspect, int duration, String... tags);
 }

--- a/output-api/src/main/java/org/eigengo/monitor/output/NullCounterInterface.java
+++ b/output-api/src/main/java/org/eigengo/monitor/output/NullCounterInterface.java
@@ -11,12 +11,12 @@ public class NullCounterInterface implements CounterInterface {
     }
 
     @Override
-    public void decrementCounter(String aspect, String... tags) {
+    public void recordGaugeValue(String aspect, int value, String... tags) {
         // noop
     }
 
     @Override
-    public void recordGaugeValue(String aspect, int value, String... tags) {
+    public void recordExecutionTime(String aspect, int duration, String... tags) {
         // noop
     }
 }

--- a/output-statsd/src/main/java/org/eigengo/monitor/output/statsd/StatsdCounterInterface.java
+++ b/output-statsd/src/main/java/org/eigengo/monitor/output/statsd/StatsdCounterInterface.java
@@ -16,13 +16,13 @@ public class StatsdCounterInterface implements CounterInterface {
     }
 
     @Override
-    public void decrementCounter(String aspect, String... tags) {
-        statsd.decrementCounter(aspect, tags);
+    public void recordGaugeValue(String aspect, int value, String... tags) {
+        statsd.recordGaugeValue(aspect, value, tags);
     }
 
     @Override
-    public void recordGaugeValue(String aspect, int value, String... tags) {
-        statsd.recordGaugeValue(aspect, value, tags);
+    public void recordExecutionTime(String aspect, int duration, String... tags) {
+        statsd.recordExecutionTime(aspect, duration, tags);
     }
 
 


### PR DESCRIPTION
Record the errors in the actor's `receive` function; errors mean exceptions propagating from the `receive` function. 

This is distinct from dropped messages, which are messages that are sent to an actor, but are not handled in the `receive` function.

Close #5.
