### PR TITLE
Class name in the tag

### DIFF
--- a/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/AbstractMonitoringAspect.aj
+++ b/agent-akka/src/main/aj/org/eigengo/monitor/agent/akka/AbstractMonitoringAspect.aj
@@ -10,6 +10,8 @@ abstract aspect AbstractMonitoringAspect {
     protected boolean includeSystemActors = false;
     // if true, the monitoring will include the child actors created as routees
     protected boolean includeRoutees = true;
+    // if true, the monitoring will include the actor class name as one of the tags
+    protected boolean includeActorClassName = true;
 
     protected static final CounterInterface counterInterface = createCounterInterface();
 

--- a/test/src/main/scala/org/eigengo/monitor/TestCounterInterface.scala
+++ b/test/src/main/scala/org/eigengo/monitor/TestCounterInterface.scala
@@ -116,7 +116,7 @@ object TestCounterInterface {
       })
 
     counters.foldLeft[List[TestCounter]](Nil) { (b, a) =>
-      if (a.aspect == aspect) b.find(pred).map(fold(a, _)).getOrElse(a) :: b else b
+      if (pred(a)) b.find(pred).map(fold(a, _)).getOrElse(a) :: b else b
     }
   }
 


### PR DESCRIPTION
Configurable by setting the `AbstractMonitoringAspect.includeActorClassName`. When `true`, the tags will include `akka:{systemName}.{canonicalClass}`, where `{systemName}` is the `ActorSystem`'s name; `{canonicalClass}` is the canonical class name of the actor.

Close #33.
