### PR TITLE
Change pointcut definition for actorOf

### DIFF
--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -208,7 +208,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
     }
 
     /**
-     * Advises the {@code actorOf} method of {@code ActorCell} and {@code ActorSystem}
+     * Advises the {@code actorOf} method of {@code ActorRefFactory} implementations
      *
      * @param props the {@code Props} instance used in the call
      * @param actor the {@code ActorRef} returned from the call
@@ -217,7 +217,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
         recordActorCreation(props, actor);
     }
     /**
-     * Advises the {@code actorOf} method of {@code ActorCell} and {@code ActorSystem} when actor is named in construction
+     * Advises the {@code actorOf} method of {@code ActorRefFactory} implementations when actor is named in construction
      *
      * @param props the {@code Props} instance used in the call
      * @param actorName the {@code String} used to name the actor at creation site

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -216,16 +216,6 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
     after(Props props) returning (ActorRef actor): Pointcuts.anyActorOf(props) {
         recordActorCreation(props, actor);
     }
-    /**
-     * Advises the {@code actorOf} method of {@code ActorRefFactory} implementations when actor is named in construction
-     *
-     * @param props the {@code Props} instance used in the call
-     * @param actorName the {@code String} used to name the actor at creation site
-     * @param actor the {@code ActorRef} returned from the call
-     */
-    after(Props props, String actorName) returning (ActorRef actor): Pointcuts.namedActorOf(props, actorName) {
-        recordActorCreation(props, actor);
-    }
 
     /**
      * method containing the recording logic for advising actor creation

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -213,14 +213,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      * @param props the {@code Props} instance used in the call
      * @param actor the {@code ActorRef} returned from the call
      */
-    after(Props props) returning (ActorRef actor): Pointcuts.anyActorOf(props) {
-        recordActorCreation(props, actor);
-    }
-
-    /**
-     * method containing the recording logic for advising actor creation
-     * */
-    private void recordActorCreation(Props props, ActorRef actor) {
+    after(Props props) returning (ActorRef actor) : Pointcuts.anyActorOf(props) {
         if (!includeActorPath(new PathAndClass(actor.path(), this.noActorClazz))) return;
         final String uncheckedClassName = uncheckedActorNameFrom(props);
         final Option<String> className = Option.apply(uncheckedClassName);

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -47,13 +47,17 @@ abstract aspect Pointcuts {
      * Pointcut for the {@code actorOf} method in {@code ActorRefFactory} implementations. You would typically use
      * it in the {@code after returning()} advices.
      */
-    static pointcut anyActorOf(Props props) :
-            execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props);
+    private pointcut unnamedActorOf(Props props) : execution(* akka.actor.ActorRefFactory+.actorOf(*)) && args(props);
     /**
      * Pointcut for the {@code actorOf} method in {@code ActorRefFactory} implementations where actor is named on creation
      */
-    static pointcut namedActorOf(Props props, String actorName) :
-            execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props, actorName);
+    private pointcut namedActorOf(Props props) : execution(* akka.actor.ActorRefFactory+.actorOf(*,*)) && args(props, *);
+    /**
+     * Public pointcut for retrieving Props instance used by {@code actorOf} method in {@code ActorRefFactory}
+     */
+    pointcut anyActorOf(Props props) : namedActorOf(props) || unnamedActorOf(props);
+
+
 
 
     /**

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -18,7 +18,6 @@ package org.eigengo.monitor.agent.akka;
 import akka.actor.ActorCell;
 import akka.actor.ActorRef;
 import akka.actor.Props;
-import akka.actor.LocalActorRef;
 
 /**
  * Centralises the pointcuts
@@ -45,16 +44,17 @@ abstract aspect Pointcuts {
             execution(* akka.event.EventStream.publish(..)) && args(event);
 
     /**
-     * Pointcut for the {@code actorOf} methods in {@code ActorCell} and {@code ActorSystem}. You would typically use
+     * Pointcut for the {@code actorOf} method in {@code ActorRefFactory} implementations. You would typically use
      * it in the {@code after returning()} advices.
      */
-    static pointcut anyActorOf(Props props) : (execution(* akka.actor.ActorSystem.actorOf(..)) || execution(* akka.actor.ActorCell.actorOf(..))) && args(props);
+    static pointcut anyActorOf(Props props) :
+            execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props);
     /**
-     * Pointcut for the {@code actorOf} methods in {@code ActorCell} and {@code ActorSystem} where actor is named on creation
+     * Pointcut for the {@code actorOf} method in {@code ActorRefFactory} implementations where actor is named on creation
      */
     static pointcut namedActorOf(Props props, String actorName) :
-            (execution(* akka.actor.ActorSystem.actorOf(..)) ||
-                execution(* akka.actor.ActorCell.actorOf(..))) && args(props, actorName);
+            execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props, actorName);
+
 
     /**
      * Pointcut for {@code ActorCell.stop(actor)} method, extracting the {@code ActorRef}

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -47,11 +47,13 @@ abstract aspect Pointcuts {
      * Pointcut for the {@code actorOf} method in {@code ActorRefFactory} implementations. You would typically use
      * it in the {@code after returning()} advices.
      */
-    private static pointcut unnamedActorOf(Props props) : execution(* akka.actor.ActorRefFactory+.actorOf(*)) && args(props);
+    private static pointcut unnamedActorOf(Props props) :
+            execution(* akka.actor.ActorRefFactory+.actorOf(*)) && args(props);
     /**
      * Pointcut for the {@code actorOf} method in {@code ActorRefFactory} implementations where actor is named on creation
      */
-    private static pointcut namedActorOf(Props props) : execution(* akka.actor.ActorRefFactory+.actorOf(*,*)) && args(props, *);
+    private static pointcut namedActorOf(Props props) :
+            execution(* akka.actor.ActorRefFactory+.actorOf(*,*)) && args(props, *);
     /**
      * Public pointcut for retrieving Props instance used by {@code actorOf} method in {@code ActorRefFactory}
      */

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -47,15 +47,15 @@ abstract aspect Pointcuts {
      * Pointcut for the {@code actorOf} method in {@code ActorRefFactory} implementations. You would typically use
      * it in the {@code after returning()} advices.
      */
-    private pointcut unnamedActorOf(Props props) : execution(* akka.actor.ActorRefFactory+.actorOf(*)) && args(props);
+    private static pointcut unnamedActorOf(Props props) : execution(* akka.actor.ActorRefFactory+.actorOf(*)) && args(props);
     /**
      * Pointcut for the {@code actorOf} method in {@code ActorRefFactory} implementations where actor is named on creation
      */
-    private pointcut namedActorOf(Props props) : execution(* akka.actor.ActorRefFactory+.actorOf(*,*)) && args(props, *);
+    private static pointcut namedActorOf(Props props) : execution(* akka.actor.ActorRefFactory+.actorOf(*,*)) && args(props, *);
     /**
      * Public pointcut for retrieving Props instance used by {@code actorOf} method in {@code ActorRefFactory}
      */
-    pointcut anyActorOf(Props props) : namedActorOf(props) || unnamedActorOf(props);
+    static pointcut anyActorOf(Props props) : namedActorOf(props) || unnamedActorOf(props);
 
 
 

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
@@ -55,6 +55,20 @@ class UnfilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspectS
       TestCounterInterface.foldlByAspect(actorCount)((a,_) =>a) must contain(TestCounter(actorCount, 0, List(tag)))
     }
 
+    "Record the actor count using a creator" in {
+      TestCounterInterface.clear()
+      val tag = "org.eigengo.monitor.agent.akka.SimpleActor"
+
+      val simpleActor = system.actorOf(Props.create(new SimpleActorCreator))
+
+      // stop(self)
+      simpleActor ! 'stop
+
+      Thread.sleep(500) // wait for the messages
+      // we're sending gauge values here. We want the latest (hence our fold takes the 'head')
+      TestCounterInterface.foldlByAspect(actorCount)((a, _) => a) must contain(TestCounter(actorCount, 0, List(tag)))
+    }
+
     // records the count of messages received, grouped by message type
     "Record the message sent to actor" in {
       val actorName = "foo"

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
@@ -69,6 +69,20 @@ class UnfilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspectS
       TestCounterInterface.foldlByAspect(actorCount)((a, _) => a) must contain(TestCounter(actorCount, 0, List(tag)))
     }
 
+    "Record the actor count of a named actor using a creator" in {
+      TestCounterInterface.clear()
+      val tag = "org.eigengo.monitor.agent.akka.SimpleActor"
+
+      val simpleActor = system.actorOf(Props.create(new SimpleActorCreator), "SomeMame")
+      TestCounterInterface.foldlByAspect(actorCount)((a, _) => a) must contain(TestCounter(actorCount, 1, List(tag)))
+      // stop(self)
+      simpleActor ! 'stop
+
+      Thread.sleep(500) // wait for the messages
+      // we're sending gauge values here. We want the latest (hence our fold takes the 'head')
+      TestCounterInterface.foldlByAspect(actorCount)((a, _) => a) must contain(TestCounter(actorCount, 0, List(tag)))
+    }
+
     // records the count of messages received, grouped by message type
     "Record the message sent to actor" in {
       val actorName = "foo"

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
@@ -60,7 +60,7 @@ class UnfilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspectS
       val tag = "org.eigengo.monitor.agent.akka.SimpleActor"
 
       val simpleActor = system.actorOf(Props.create(new SimpleActorCreator))
-
+      TestCounterInterface.foldlByAspect(actorCount)((a, _) => a) must contain(TestCounter(actorCount, 1, List(tag)))
       // stop(self)
       simpleActor ! 'stop
 

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/actors.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/actors.scala
@@ -34,6 +34,9 @@ class SimpleActor extends Actor {
 
 }
 
+/**
+ * Creator implementation to test Akka Java API
+ */
 class SimpleActorCreator extends Creator[SimpleActor] {
   def create(): SimpleActor = new SimpleActor
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/actors.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/actors.scala
@@ -34,7 +34,7 @@ class SimpleActor extends Actor {
 
 }
 
-class SimpleActorCreator extends Creator[SimpleActor]{
+class SimpleActorCreator extends Creator[SimpleActor] {
   def create(): SimpleActor = new SimpleActor
 }
 

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/actors.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/actors.scala
@@ -16,6 +16,7 @@
 package org.eigengo.monitor.agent.akka
 
 import akka.actor.Actor
+import akka.japi.Creator
 
 class SimpleActor extends Actor {
 
@@ -31,6 +32,10 @@ class SimpleActor extends Actor {
       throw new RuntimeException("Bantha poodoo!")
   }
 
+}
+
+class SimpleActorCreator extends Creator[SimpleActor]{
+  def create(): SimpleActor = new SimpleActor
 }
 
 class WithUnhandledActor extends Actor {

--- a/docs/rst/engineering/pointcuts.rst
+++ b/docs/rst/engineering/pointcuts.rst
@@ -5,18 +5,17 @@ Pointcuts
 Actor creation pointcuts
 ========================
 
-Pointcut for the ``actorOf(..)`` methods in ``ActorCell`` and ``ActorSystem``, extracting the ``Props`` being used::
+Pointcut for the ``actorOf(..)`` method in ``ActorRefFactory`` implementations, extracting the ``Props`` being used::
 
     static pointcut anyActorOf(Props props) :
-        (execution(* akka.actor.ActorSystem.actorOf(..)) ||
-            execution(* akka.actor.ActorCell.actorOf(..))) && args(props);
+        execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props);
 
 
-Pointcut for the ``actorOf(..)`` methods in ``ActorCell`` and ``ActorSystem`` where actor is named on creation, extracting the ``Props`` being used, and the ``String`` name of the actor::
+
+Pointcut for the ``actorOf(..)`` method in ``ActorRefFactory`` implementations where actor is named on creation, extracting the ``Props`` being used, and the ``String`` name of the actor::
 
     static pointcut namedActorOf(Props props, String actorName) :
-        (execution(* akka.actor.ActorSystem.actorOf(..)) ||
-            execution(* akka.actor.ActorCell.actorOf(..))) && args(props, actorName);
+        execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props, actorName);
 
 
 Actor death pointcuts

--- a/docs/rst/engineering/pointcuts.rst
+++ b/docs/rst/engineering/pointcuts.rst
@@ -8,13 +8,13 @@ Actor creation pointcuts
 Pointcut for the ``actorOf(..)`` method in ``ActorRefFactory`` implementations, extracting the ``Props`` being used::
 
     private static pointcut unnamedActorOf(Props props) :
-        execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props);
+        execution(* akka.actor.ActorRefFactory+.actorOf(*)) && args(props);
 
 
 Pointcut for the ``actorOf(..)`` method in ``ActorRefFactory`` implementations where actor is named on creation, extracting the ``Props`` being used, and the ``String`` name of the actor::
 
-    private static pointcut namedActorOf(Props props, String actorName) :
-        execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props, actorName);
+    private static pointcut namedActorOf(Props props) :
+        execution(* akka.actor.ActorRefFactory+.actorOf(*,*)) && args(props, *);
 
 
 Public pointcut for exposing ``Props`` obtained from ``actorOf(..)`` methods in ``ActorRefFactory`` implementations, whether new actor is named or not.

--- a/docs/rst/engineering/pointcuts.rst
+++ b/docs/rst/engineering/pointcuts.rst
@@ -7,15 +7,19 @@ Actor creation pointcuts
 
 Pointcut for the ``actorOf(..)`` method in ``ActorRefFactory`` implementations, extracting the ``Props`` being used::
 
-    static pointcut anyActorOf(Props props) :
+    private static pointcut unnamedActorOf(Props props) :
         execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props);
-
 
 
 Pointcut for the ``actorOf(..)`` method in ``ActorRefFactory`` implementations where actor is named on creation, extracting the ``Props`` being used, and the ``String`` name of the actor::
 
-    static pointcut namedActorOf(Props props, String actorName) :
+    private static pointcut namedActorOf(Props props, String actorName) :
         execution(* akka.actor.ActorRefFactory+.actorOf(..)) && args(props, actorName);
+
+
+Public pointcut for exposing ``Props`` obtained from ``actorOf(..)`` methods in ``ActorRefFactory`` implementations, whether new actor is named or not.
+
+    static pointcut anyActorOf(Props props) : namedActorOf(props) || unnamedActorOf(props);
 
 
 Actor death pointcuts

--- a/docs/rst/engineering/pointcuts.rst
+++ b/docs/rst/engineering/pointcuts.rst
@@ -17,7 +17,7 @@ Pointcut for the ``actorOf(..)`` method in ``ActorRefFactory`` implementations w
         execution(* akka.actor.ActorRefFactory+.actorOf(*,*)) && args(props, *);
 
 
-Public pointcut for exposing ``Props`` obtained from ``actorOf(..)`` methods in ``ActorRefFactory`` implementations, whether new actor is named or not.
+Public pointcut for exposing ``Props`` obtained from ``actorOf(..)`` methods in ``ActorRefFactory`` implementations, whether new actor is named or not.::
 
     static pointcut anyActorOf(Props props) : namedActorOf(props) || unnamedActorOf(props);
 

--- a/docs/rst/intro.rst
+++ b/docs/rst/intro.rst
@@ -67,8 +67,8 @@ When you execute this application, and issue a few ``go`` commands; and a few in
 If you don't want to write the code yourself, all you have to do is to add the ``libraryDependencies``::
 
 
-    "org.eigengo.monitor" % "agent-akka" % "0.1-SNAPSHOT"
-    "org.eigengo.monitor" % "output-statsd" % "0.1-SNAPSHOT"
+    "org.eigengo.monitor" % "agent-akka" % "0.2-SNAPSHOT"
+    "org.eigengo.monitor" % "output-statsd" % "0.2-SNAPSHOT"
 
 Once you have the added the dependencies to your module, add files ``/META-INF/aop.xml`` and ``/META-INF/monitor/agent.conf``, start your JVM with ``-javaagent:$PATH-TO/aspectjweaver-1.7.3.jar``, start the `Datadog <http://http://www.datadoghq.com/>`_ agent, and you're all ready to keep an eye on your Akka code.
 

--- a/docs/rst/intro.rst
+++ b/docs/rst/intro.rst
@@ -67,8 +67,8 @@ When you execute this application, and issue a few ``go`` commands; and a few in
 If you don't want to write the code yourself, all you have to do is to add the ``libraryDependencies``::
 
 
-    "org.eigengo.monitor" % "agent-akka" % "0.1-SNAPSHOT"
-    "org.eigengo.monitor" % "output-statsd" % "0.1-SNAPSHOT"
+    "org.eigengo.monitor" % "agent-akka" % "@version@"
+    "org.eigengo.monitor" % "output-statsd" % "@version@"
 
 Once you have the added the dependencies to your module, add files ``/META-INF/aop.xml`` and ``/META-INF/monitor/agent.conf``, start your JVM with ``-javaagent:$PATH-TO/aspectjweaver-1.7.3.jar``, start the `Datadog <http://http://www.datadoghq.com/>`_ agent, and you're all ready to keep an eye on your Akka code.
 


### PR DESCRIPTION
The actual pointcut definition don't catch actor creation using the Akka Java API.

This pr change the pointcut definition to catch every implementation of `ActorRefFactory` Trait

Fix issue #78 
