### PR TITLE
Can specify multiple actor types in included/excluded/sampling filters

### DIFF
--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -65,7 +65,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
         }
 
         // skip if not included
-        if (!this.agentConfiguration.included().accept(pathAndClass)) return false;
+        if (this.agentConfiguration.included().accept(pathAndClass)) return true;
         // skip if excluded
         if (this.agentConfiguration.excluded().accept(pathAndClass)) return false;
 

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -64,9 +64,9 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
             if (pathAndClass.actorClassName().get().startsWith("org.eigengo.monitor.output")) return false;
         }
 
-        // skip if not included
+        // include actor if it's in 'included' list
         if (this.agentConfiguration.included().accept(pathAndClass)) return true;
-        // skip if excluded
+        // exclude actor if excluded (i.e. is in 'excluded' list, or excludeAllNotIncluded = true, and actor is not included)
         if (this.agentConfiguration.excluded().accept(pathAndClass)) return false;
 
         // skip system actor checks if we wish to monitor them

--- a/agent-akka/src/main/scala/org/eigengo/monitor/agent/akka/configuration.scala
+++ b/agent-akka/src/main/scala/org/eigengo/monitor/agent/akka/configuration.scala
@@ -49,14 +49,14 @@ object AkkaAgentConfiguration {
   def apply(config: Config): AkkaAgentConfiguration = {
     import scala.collection.JavaConversions._
 
-    val allowExclusions = if (config.hasPath("allowExclusions")) config.getBoolean("allowExclusions") else false
+    val excludeAllNotIncluded = if (config.hasPath("excludeAllNotIncluded")) config.getBoolean("excludeAllNotIncluded") else false
     val includeRoutees = if (config.hasPath("includeRoutees")) config.getBoolean("includeRoutees") else false
     val includeSystemAgents = if (config.hasPath("includeSystemAgents")) config.getBoolean("includeSystemAgents") else false
     val included = if (config.hasPath("included")) config.getStringList("included").map(parseFilter).toList else Nil
     val excluded = if (config.hasPath("excluded")) config.getStringList("excluded").map(parseFilter).toList else Nil
     val sampling = if (config.hasPath("sampling")) config.getObjectList("sampling").flatMap(parseSampling).toList else Nil
-    AkkaAgentConfiguration(includeRoutees, includeSystemAgents, AnyAcceptActorFilter(included, true),
-                            AnyAcceptActorFilter(excluded, allowExclusions), SamplingRates(sampling))
+    AkkaAgentConfiguration(includeRoutees, includeSystemAgents, AnyAcceptActorFilter(included, false),
+                            AnyAcceptActorFilter(excluded, excludeAllNotIncluded), SamplingRates(sampling))
   }
 
   private def parseActorSystemFilter(actorSystemName: String): ActorSystemNameFilter =

--- a/agent-akka/src/main/scala/org/eigengo/monitor/agent/akka/configuration.scala
+++ b/agent-akka/src/main/scala/org/eigengo/monitor/agent/akka/configuration.scala
@@ -51,10 +51,11 @@ object AkkaAgentConfiguration {
 
     val allowExclusions = if (config.hasPath("allowExclusions")) config.getBoolean("allowExclusions") else false
     val includeRoutees = if (config.hasPath("includeRoutees")) config.getBoolean("includeRoutees") else false
+    val includeSystemAgents = if (config.hasPath("includeSystemAgents")) config.getBoolean("includeSystemAgents") else false
     val included = if (config.hasPath("included")) config.getStringList("included").map(parseFilter).toList else Nil
     val excluded = if (config.hasPath("excluded")) config.getStringList("excluded").map(parseFilter).toList else Nil
     val sampling = if (config.hasPath("sampling")) config.getObjectList("sampling").flatMap(parseSampling).toList else Nil
-    AkkaAgentConfiguration(includeRoutees, false, AnyAcceptActorFilter(included, true),
+    AkkaAgentConfiguration(includeRoutees, includeSystemAgents, AnyAcceptActorFilter(included, true),
                             AnyAcceptActorFilter(excluded, allowExclusions), SamplingRates(sampling))
   }
 

--- a/agent-akka/src/main/scala/org/eigengo/monitor/agent/akka/filters.scala
+++ b/agent-akka/src/main/scala/org/eigengo/monitor/agent/akka/filters.scala
@@ -65,9 +65,8 @@ sealed trait ActorFilter {
  * @param zero the zero
  */
 case class AnyAcceptActorFilter(filters: List[ActorFilter], zero: Boolean) extends ActorFilter {
-  override def accept(pathAndClass: PathAndClass): Boolean = {
-    filters.foldLeft(zero)((b, filter) => b || filter.accept(pathAndClass))
-  }
+  override def accept(pathAndClass: PathAndClass): Boolean =
+    (zero || filters.exists(_.accept(pathAndClass)))
 }
 
 /**

--- a/agent-akka/src/main/scala/org/eigengo/monitor/agent/akka/filters.scala
+++ b/agent-akka/src/main/scala/org/eigengo/monitor/agent/akka/filters.scala
@@ -66,8 +66,7 @@ sealed trait ActorFilter {
  */
 case class AnyAcceptActorFilter(filters: List[ActorFilter], zero: Boolean) extends ActorFilter {
   override def accept(pathAndClass: PathAndClass): Boolean = {
-    for (filter <- filters) if (!filter.accept(pathAndClass)) return false
-    zero
+    filters.foldLeft(zero)((b, filter) => b || filter.accept(pathAndClass))
   }
 }
 

--- a/agent-akka/src/test/resources/META-INF/monitor/path-filter.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/path-filter.conf
@@ -1,4 +1,5 @@
 {
     includeRoutees: true
+    excludeAllNotIncluded: true
     included: [ "akka://default/user/a" ]
 }

--- a/agent-akka/src/test/resources/META-INF/monitor/sample.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/sample.conf
@@ -14,7 +14,6 @@
             for: [ "akka://default/user/*" ]
         }
     ]
-    allowExclusions = true
     excluded: [ "akka:*.org.eigengo.monitor.agent.akka.NullTestingActor3" ]
 
 }

--- a/agent-akka/src/test/resources/META-INF/monitor/type-filter.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/type-filter.conf
@@ -1,7 +1,10 @@
 {
     includeRoutees: true
+    excludeAllNotIncluded: true
     included: [
-        "akka:*.org.eigengo.monitor.agent.akka.SimpleActor"
+        "akka:default.org.eigengo.monitor.agent.akka.SimpleActor",
+        "akka:*.org.eigengo.monitor.agent.akka.NullTestingActor1",
+        "akka:*.org.eigengo.monitor.agent.akka.NullTestingActor2"
     ]
     sampling: [
         {

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/TypeFilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/TypeFilteredActorCellMonitoringAspectSpec.scala
@@ -48,8 +48,8 @@ class TypeFilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspec
 
       // we expect to see 2 integers, 1 string and 1 undelivered
       val counter = TestCounterInterface.foldlByAspect(deliveredInteger)(TestCounter.plus)
-      counter(0).value mustEqual 1                      // "akka:*.org.eigengo.monitor.agent.akka.SimpleActor" sampling rate is 1.
-      counter.size mustEqual 1                          // and WithUnhandledActor isn't included
+      counter.size mustEqual 1                          // "akka:*.org.eigengo.monitor.agent.akka.SimpleActor" sampling rate is 1
+      counter(0).value mustEqual 1                      // and WithUnhandledActor isn't included
       counter(0).tags must contain(a.path.toString)     // so this should be true whether or not sampling is working.
     }
 
@@ -77,7 +77,7 @@ class TypeFilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspec
       counter2(0).value mustEqual 1005
       counter2(0).tags must contain(d.path.toString)
       counter2.size === 67
-    }.pendingUntilFixed("we should be able to include more than one actor!")
+    }
 
 
     "Skip sampled non-included actors" in {

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
@@ -47,14 +47,14 @@ class UnfilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspectS
       val tag = "org.eigengo.monitor.agent.akka.SimpleActor"
       val simpleActor = system.actorOf(Props[SimpleActor], actorName)
 
-      TestCounterInterface.foldlByAspect(actorCount)((a,_) =>a) must contain(TestCounter(actorCount, 1, List(tag)))
+      TestCounterInterface.foldlByAspect(actorCount)((a, _) => a) must contain(TestCounter(actorCount, 1, List(tag)))
 
       // stop(self)
       simpleActor ! 'stop
 
       Thread.sleep(500)   // wait for the messages
        // we're sending gauge values here. We want the latest (hence our fold takes the 'head')
-      TestCounterInterface.foldlByAspect(actorCount)((a,_) =>a) must contain(TestCounter(actorCount, 0, List(tag)))
+      TestCounterInterface.foldlByAspect(actorCount)((a, _) => a) must contain(TestCounter(actorCount, 0, List(tag)))
     }
 
     "Record the actor count using a creator" in {

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
@@ -47,6 +47,8 @@ class UnfilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspectS
       val tag = "org.eigengo.monitor.agent.akka.SimpleActor"
       val simpleActor = system.actorOf(Props[SimpleActor], actorName)
 
+      TestCounterInterface.foldlByAspect(actorCount)((a,_) =>a) must contain(TestCounter(actorCount, 1, List(tag)))
+
       // stop(self)
       simpleActor ! 'stop
 


### PR DESCRIPTION
Previously we were a bit too limited in what we could match with our inclusion/exclusion filters. In addition, the rather confusing 'allowExclusions' boolean has been renamed 'excludeAllNotIncluded'

Fix issue #81
