### PR TITLE
Actor type montoring

### DIFF
--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -355,11 +355,10 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
         final ActorPath actorPath = actor.self().path();
         final PathAndClass pac = new PathAndClass(actorPath, Option.apply(className));
         if (this.pathTags.containsKey(actorPath)) return; // the key is there, we need do nothing.
+        // add the path -> type pair to the pathTags map
+        this.pathTags.putIfAbsent(actorPath, className);
 
         if (includeActorPath(pac)) {
-            // add the path -> type pair to the pathTags map
-            this.pathTags.putIfAbsent(actorPath, className);
-
             // safe increment of the count of actors of this type
             this.numberOfActors.putIfAbsent(pac.actorClassName(), new AtomicInteger(0));
             final int currentNumberOfActors = this.numberOfActors.get(pac.actorClassName()).incrementAndGet();

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -30,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Contains advices for monitoring behaviour of an actor; typically imprisoned in an {@code ActorCell}.
  */
-public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingleton() {
+public final aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingleton() {
     private AkkaAgentConfiguration agentConfiguration;
     private final CounterInterface counterInterface;
     private final Option<String> anonymousActorClassName = Option.empty();
@@ -350,12 +350,11 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      *
      * @param actor the Actor returned by the {@code Creator.create()} method
      * */
-    Actor around() : Pointcuts.actorCreator() {
-        final Actor actor = proceed();
+    after() returning(Actor actor) : Pointcuts.actorCreator() {
         final String className = actor.getClass().getCanonicalName();
         final ActorPath actorPath = actor.self().path();
         final PathAndClass pac = new PathAndClass(actorPath, Option.apply(className));
-        if (this.pathTags.containsKey(actorPath)) return actor; // the key is there, we need do nothing.
+        if (this.pathTags.containsKey(actorPath)) return; // the key is there, we need do nothing.
         // add the path -> type pair to the pathTags map
         this.pathTags.putIfAbsent(actorPath, className);
 
@@ -372,7 +371,6 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
             final int currentNumberOfActors = this.numberOfActors.get(this.anonymousActorClassName).decrementAndGet();
             this.counterInterface.recordGaugeValue(Aspects.actorCount(), currentNumberOfActors, getTags(actorPath, this.anonymousActorClassName));
         }
-        return actor;
     }
 
 }

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -34,7 +34,9 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
     private AkkaAgentConfiguration agentConfiguration;
     private final CounterInterface counterInterface;
     private final Option<String> anonymousActorClassName = Option.empty();
+    // we sample based on actor type (i.e. a sampling rate of 'n' for a filter means 'every nth actor with type k, for each type k that matches that filter')
     private final ConcurrentHashMap<Option<String>, AtomicLong> samplingCounters  = new ConcurrentHashMap<Option<String>, AtomicLong>();
+    // we count actors by actor type (any 'anonymous' or 'generic' actors are treated as the same type)
     private final ConcurrentHashMap<Option<String>, AtomicInteger> numberOfActors = new ConcurrentHashMap<Option<String>, AtomicInteger>();
     private final ConcurrentHashMap<ActorPath, String> pathTags                   = new ConcurrentHashMap<ActorPath, String>();
 

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -350,7 +350,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
     after() returning(final Actor actor) : Pointcuts.actorCreator() {
         final String className = actor.getClass().getCanonicalName();
         final ActorPath actorPath = actor.self().path();
-        if this.pathTags.containsKey(actorPath) return;
+        if (this.pathTags.containsKey(actorPath)) return;
         // add the path -> type pair to the pathTags map
         this.pathTags.putIfAbsent(actorPath, className);
 

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -326,7 +326,14 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
         return Option.apply(canonicalName);
     }
 
-    after() returning(Actor actor) : Pointcuts.actorCreator() {
+    /**
+     * Catches actors created by the japi.Creator.create(), at a point when their type is visible to the runtime.
+     * We use the visibility of the type at this one pointcut to create a map from the actor path to its type,
+     * which we then access within the other pointcuts (notably on actor death and message receipt) to
+     *
+     * @param actor the Actor returned by the {@code Creator.create()} method
+     * */
+    after() returning(final Actor actor) : Pointcuts.actorCreator() {
         final String className = actor.getClass().getCanonicalName();
         final ActorPath actorPath = actor.self().path();
         this.pathTags.putIfAbsent(actorPath, className);

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -366,7 +366,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
         this.numberOfActors.putIfAbsent(this.anonymousActorClassName, new AtomicInteger(0));
                 // reuse of int for (almost-?)invisible performance improvement
         currentNumberOfActors = this.numberOfActors.get(this.anonymousActorClassName).decrementAndGet();
-        this.counterInterface.recordGaugeValue(Aspects.actorCount(), currentNumberOfActors, getTags(actorPath, Option.apply(className)));
+        this.counterInterface.recordGaugeValue(Aspects.actorCount(), currentNumberOfActors, getTags(actorPath, this.anonymousActorClassName));
     }
 
 }

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -188,6 +188,9 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      * @return whether to include the given actor in the metrics
      */
     private boolean includeActorPath(final PathAndClass pathAndClass) {
+        if (pathAndClass.actorClassName().isDefined() && pathAndClass.actorClassName().get().contains("GreetPrinter")) {
+            System.out.println("£  :  "+pathAndClass.actorPath());
+        }
         // do not monitor our own output code
         if (pathAndClass.actorClassName().isDefined()) {
             if (pathAndClass.actorClassName().get().startsWith("org.eigengo.monitor.output")) return false;
@@ -317,6 +320,17 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      */
     private Option<String> getActorClassName(final Props props) {
         final String canonicalName = props.actorClass().getCanonicalName();
+//
+//        final Class<?> something = props.clazz();
+//        Class<?> interim = props.actorClass();
+//        System.out.println("##@ 0 : "+something.toString());
+//        System.out.println("##@ 1 : "+interim.getDeclaredClasses().length);
+//        System.out.println("##@ 2 : "+interim);
+//
+//        for (int i = 0; i < interim.getDeclaredClasses().length; i++) {
+//            System.out.println("##@ "+(i+2)+" : "+interim.getDeclaredClasses()[i].toString());
+//        }
+
         if (canonicalName == null) return this.anonymousActorClassName;
 
         return Option.apply(canonicalName);

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -188,9 +188,6 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      * @return whether to include the given actor in the metrics
      */
     private boolean includeActorPath(final PathAndClass pathAndClass) {
-        if (pathAndClass.actorClassName().isDefined() && pathAndClass.actorClassName().get().contains("GreetPrinter")) {
-            System.out.println("£  :  "+pathAndClass.actorPath());
-        }
         // do not monitor our own output code
         if (pathAndClass.actorClassName().isDefined()) {
             if (pathAndClass.actorClassName().get().startsWith("org.eigengo.monitor.output")) return false;
@@ -230,7 +227,6 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
 
         this.samplingCounters.putIfAbsent(pathAndClass, new AtomicLong(0));
         long timesSeenSoFar = this.samplingCounters.get(pathAndClass).incrementAndGet();
-
         return (timesSeenSoFar % sampleRate == 1); // == 1 to log first value (incrementAndGet returns updated value)
     }
 
@@ -320,17 +316,6 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      */
     private Option<String> getActorClassName(final Props props) {
         final String canonicalName = props.actorClass().getCanonicalName();
-//
-//        final Class<?> something = props.clazz();
-//        Class<?> interim = props.actorClass();
-//        System.out.println("##@ 0 : "+something.toString());
-//        System.out.println("##@ 1 : "+interim.getDeclaredClasses().length);
-//        System.out.println("##@ 2 : "+interim);
-//
-//        for (int i = 0; i < interim.getDeclaredClasses().length; i++) {
-//            System.out.println("##@ "+(i+2)+" : "+interim.getDeclaredClasses()[i].toString());
-//        }
-
         if (canonicalName == null) return this.anonymousActorClassName;
 
         return Option.apply(canonicalName);

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -323,9 +323,12 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      */
     private Option<String> getActorClassName(final Props props, final ActorPath actorPath) {
         final String canonicalName = props.actorClass().getCanonicalName();
-        if (this.pathTags.containsKey(actorPath)) return Option.apply(this.pathTags.get(actorPath));
         if (canonicalName == null /*if actor is anonymous*/||/*OR actor is generic*/
-                canonicalName.endsWith("akka.actor.Actor")) return this.anonymousActorClassName;
+                canonicalName.endsWith("akka.actor.Actor")) {
+            // then we check to see if our path->className map can help...
+            if (this.pathTags.containsKey(actorPath)) return Option.apply(this.pathTags.get(actorPath));
+            return this.anonymousActorClassName;
+        }
         return Option.apply(canonicalName);
     }
 

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -16,6 +16,7 @@
 package org.eigengo.monitor.agent.akka;
 
 import akka.actor.*;
+import akka.japi.Creator;
 import org.eigengo.monitor.agent.AgentConfiguration;
 import org.eigengo.monitor.output.CounterInterface;
 import scala.Option;
@@ -33,8 +34,9 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
     private AkkaAgentConfiguration agentConfiguration;
     private final CounterInterface counterInterface;
     private final Option<String> anonymousActorClassName = Option.empty();
-    private final ConcurrentHashMap<PathAndClass, AtomicLong> samplingCounters  = new ConcurrentHashMap<PathAndClass, AtomicLong>();
-    private final ConcurrentHashMap<PathAndClass, AtomicInteger> numberOfActors = new ConcurrentHashMap<PathAndClass, AtomicInteger>();
+    private final ConcurrentHashMap<Option<String>, AtomicLong> samplingCounters  = new ConcurrentHashMap<Option<String>, AtomicLong>();
+    private final ConcurrentHashMap<Option<String>, AtomicInteger> numberOfActors = new ConcurrentHashMap<Option<String>, AtomicInteger>();
+    private final ConcurrentHashMap<ActorPath, String> pathTags                   = new ConcurrentHashMap<ActorPath, String>();
 
     /**
      * Constructs this aspect
@@ -58,13 +60,14 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      */
     Object around(ActorCell actorCell, Object msg) : Pointcuts.actorCellReceiveMessage(actorCell, msg) {
         final ActorPath actorPath = actorCell.self().path();
-        final PathAndClass pathAndClass = new PathAndClass(actorPath, getActorClassName(actorCell));
+        final Option<String> className = getActorClassName(actorCell, actorPath);
+        final PathAndClass pathAndClass = new PathAndClass(actorPath, className);
         if (!includeActorPath(pathAndClass) || !sampleMessage(pathAndClass)) return proceed(actorCell, msg);
 
         int samplingRate = getSampleRate(pathAndClass);
 
         // we tag by actor name
-        final String[] tags = getTags(actorPath, getActorClassName(actorCell));
+        final String[] tags = getTags(actorPath, className);
 
         // record the queue size
         this.counterInterface.recordGaugeValue(Aspects.queueSize(), actorCell.numberOfMessages(), tags);
@@ -97,7 +100,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      */
     before(ActorCell actorCell, Throwable failure) : Pointcuts.actorCellHandleInvokeFailure(actorCell, failure) {
         // record the error, general and specific
-        String[] tags = getTags(actorCell.self().path(), getActorClassName(actorCell));
+        String[] tags = getTags(actorCell.self().path(), getActorClassName(actorCell, actorCell.self().path()));
         this.counterInterface.incrementCounter(Aspects.actorError(), tags);
         this.counterInterface.incrementCounter(Aspects.actorError(failure), tags);
     }
@@ -143,25 +146,27 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      * @param countType the increment or decrement
      */
      private void recordActorCount(ActorPath path, Props props, CountType countType) {
-         final PathAndClass pac = new PathAndClass(path, getActorClassName(props));
+         final Option<String> className = getActorClassName(props, path);
+         final PathAndClass pac = new PathAndClass(path, getActorClassName(props, path));
          if (!includeActorPath(pac)) return;
 
-         final String[] tags = getTags(path, pac.actorClassName());
-         this.numberOfActors.putIfAbsent(pac, new AtomicInteger(0));
+         final String[] tags = getTags(path, className);
+         this.numberOfActors.putIfAbsent(className, new AtomicInteger(0));
          // increment and get the current number of actors of this type (if the value was 0, then this returns 1 -- which is correct)
          final int currentNumberOfActors;
          switch (countType) {
              case Increment:
-                 currentNumberOfActors = this.numberOfActors.get(pac).incrementAndGet();
+                 currentNumberOfActors = this.numberOfActors.get(className).incrementAndGet();
                  break;
              case Decrement:
-                 currentNumberOfActors = this.numberOfActors.get(pac).decrementAndGet();
+                 currentNumberOfActors = this.numberOfActors.get(className).decrementAndGet();
                  break;
              default:
                  currentNumberOfActors = 0;
                  break;
          }
 
+         final String tag = (className.isDefined()) ? className.get() : "akka.actor.Actor";
          this.counterInterface.recordGaugeValue(Aspects.actorCount(), currentNumberOfActors, tags);
      }
 
@@ -222,11 +227,12 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      * @return {@code true} if we should sample this actor
      */
     private boolean sampleMessage(final PathAndClass pathAndClass) {
+        final Option<String> className = pathAndClass.actorClassName();
         int sampleRate = getSampleRate(pathAndClass);
         if (sampleRate == 1) return true;
 
-        this.samplingCounters.putIfAbsent(pathAndClass, new AtomicLong(0));
-        long timesSeenSoFar = this.samplingCounters.get(pathAndClass).incrementAndGet();
+        this.samplingCounters.putIfAbsent(className, new AtomicLong(0));
+        long timesSeenSoFar = this.samplingCounters.get(className).incrementAndGet();
         return (timesSeenSoFar % sampleRate == 1); // == 1 to log first value (incrementAndGet returns updated value)
     }
 
@@ -298,8 +304,8 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      * @param actorCell the actor cell to get the name for
      * @return the Option of actor class, never {@code null}.
      */
-    private Option<String> getActorClassName(final ActorCell actorCell) {
-        return getActorClassName(actorCell.props());
+    private Option<String> getActorClassName(final ActorCell actorCell, final ActorPath actorPath) {
+        return getActorClassName(actorCell.props(), actorPath);
     }
 
     /**
@@ -314,11 +320,24 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      * @param props the ActorRef {@code Props} instance
      * @return the Option of actor class, never {@code null}.
      */
-    private Option<String> getActorClassName(final Props props) {
+    private Option<String> getActorClassName(final Props props, final ActorPath actorPath) {
         final String canonicalName = props.actorClass().getCanonicalName();
-        if (canonicalName == null) return this.anonymousActorClassName;
-
+        if (this.pathTags.containsKey(actorPath)) return Option.apply(this.pathTags.get(actorPath));
+        if (canonicalName == null || canonicalName.endsWith("akka.actor.Actor")) return this.anonymousActorClassName;
         return Option.apply(canonicalName);
+    }
+
+    after(Creator creator) returning(Actor actor) : Pointcuts.actorCreator(creator) {
+        final String className = actor.getClass().getCanonicalName();
+        this.pathTags.putIfAbsent(actor.self().path(), className);
+
+        this.numberOfActors.putIfAbsent(Option.apply(className), new AtomicInteger(0));
+        int currentNumberOfActors = this.numberOfActors.get(Option.apply(className)).incrementAndGet();
+        this.counterInterface.recordGaugeValue(Aspects.actorCount(), currentNumberOfActors, className);
+
+        // reuse of int for almost-invisible performance improvement
+        currentNumberOfActors = this.numberOfActors.get(this.anonymousActorClassName).decrementAndGet();
+        this.counterInterface.recordGaugeValue(Aspects.actorCount(), currentNumberOfActors, "akka.actor.Actor");
     }
 
 }

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -229,10 +229,10 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
         this.samplingCounters.putIfAbsent(pathAndClass, new AtomicLong(0));
         long timesSeenSoFar = this.samplingCounters.get(pathAndClass).incrementAndGet();
         // yeah yeah. Put it somewhere else. Why?
-//        if (timesSeenSoFar == 1 && pathAndClass.actorClassName() != Option.empty()) {
-//            pathToClass.putIfAbsent(pathAndClass.actorPath(), pathAndClass.actorClassName().get());
-//        }
-//        if (sampleRate == 1) return true;
+        if (timesSeenSoFar == 1 && pathAndClass.actorClassName() != this.anonymousActorClassName) {
+            pathToClass.putIfAbsent(pathAndClass.actorPath(), pathAndClass.actorClassName().get());
+        }
+        if (sampleRate == 1) return true;
         return (timesSeenSoFar % sampleRate == 1); // == 1 to log first value (incrementAndGet returns updated value)
     }
 
@@ -293,8 +293,8 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
         }
         if (actorClassName.isDefined()) {
             tags.add(String.format("akka.type:%s.%s", actorPath.address().system(), actorClassName.get()));
-//        } else if (pathToClass.contains(actorPath)) {
-//            tags.add(String.format("akka.type:%s.%s", actorPath.address().system(), pathToClass.get(actorPath)));
+        } else if (pathToClass.contains(actorPath)) {
+            tags.add(String.format("akka.type:%s.%s", actorPath.address().system(), pathToClass.get(actorPath)));
         }
 
         return tags.toArray(new String[tags.size()]);

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -35,6 +35,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
     private final Option<String> anonymousActorClassName = Option.empty();
     private final ConcurrentHashMap<PathAndClass, AtomicLong> samplingCounters  = new ConcurrentHashMap<PathAndClass, AtomicLong>();
     private final ConcurrentHashMap<PathAndClass, AtomicInteger> numberOfActors = new ConcurrentHashMap<PathAndClass, AtomicInteger>();
+    private final ConcurrentHashMap<ActorPath, String> pathToClass              = new ConcurrentHashMap<ActorPath, String>();
 
     /**
      * Constructs this aspect
@@ -227,6 +228,11 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
 
         this.samplingCounters.putIfAbsent(pathAndClass, new AtomicLong(0));
         long timesSeenSoFar = this.samplingCounters.get(pathAndClass).incrementAndGet();
+        // yeah yeah. Put it somewhere else. Why?
+//        if (timesSeenSoFar == 1 && pathAndClass.actorClassName() != Option.empty()) {
+//            pathToClass.putIfAbsent(pathAndClass.actorPath(), pathAndClass.actorClassName().get());
+//        }
+//        if (sampleRate == 1) return true;
         return (timesSeenSoFar % sampleRate == 1); // == 1 to log first value (incrementAndGet returns updated value)
     }
 
@@ -287,6 +293,8 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
         }
         if (actorClassName.isDefined()) {
             tags.add(String.format("akka.type:%s.%s", actorPath.address().system(), actorClassName.get()));
+//        } else if (pathToClass.contains(actorPath)) {
+//            tags.add(String.format("akka.type:%s.%s", actorPath.address().system(), pathToClass.get(actorPath)));
         }
 
         return tags.toArray(new String[tags.size()]);
@@ -317,6 +325,24 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
     private Option<String> getActorClassName(final Props props) {
         final String canonicalName = props.actorClass().getCanonicalName();
         if (canonicalName == null) return this.anonymousActorClassName;
+
+//        final Class<?> something = props.clazz();
+//        System.out.println("##@ 1 : "+something.getClassLoader());
+//        System.out.println("##@ 1.1 : "+something.getClassLoader().getParent());
+//        System.out.println("##@ 1.1.1 : "+something.getClassLoader().getParent().getParent());
+////        for (int i=0; i <something.getTypeParameters().length; i++) {
+////            System.out.println("##@ 1 : "+something.getTypeParameters()[i]);
+////        }
+//        System.out.println("# 2 : "+something.getClasses());
+//        for (Class<?> i : something.getClasses()) {
+//            System.out.println("##@ 2 : "+i);
+//        }
+//        System.out.println("##@ 3 : "+something.getComponentType());
+//        System.out.println("# 4 : "+something.getInterfaces());
+//        for (Class<?> i : something.getInterfaces()) {
+//            System.out.println("##@ 4 : "+i);
+//        }
+
         return Option.apply(canonicalName);
     }
 

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -327,12 +327,18 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
         if (canonicalName == null) return this.anonymousActorClassName;
 
 //        final Class<?> something = props.clazz();
-//        System.out.println("##@ 1 : "+something.getClassLoader());
-//        System.out.println("##@ 1.1 : "+something.getClassLoader().getParent());
-//        System.out.println("##@ 1.1.1 : "+something.getClassLoader().getParent().getParent());
-////        for (int i=0; i <something.getTypeParameters().length; i++) {
-////            System.out.println("##@ 1 : "+something.getTypeParameters()[i]);
-////        }
+//        Class<?> interim = props.actorClass();
+//        System.out.println("##@ 0 : "+something.toString());
+//        System.out.println("##@ 1 : "+interim.getDeclaredClasses().length);
+//        System.out.println("##@ 1 : "+interim);
+//        for (int i = 0; i < interim.getDeclaredClasses().length; i++) {
+//            System.out.println("##@ "+(i+2)+" : "+interim.getDeclaredClasses()[i].toString());
+//        }
+
+
+//        for (int i=0; i <something.getTypeParameters().length; i++) {
+//            System.out.println("##@ 1 : "+something.getTypeParameters()[i]);
+//        }
 //        System.out.println("# 2 : "+something.getClasses());
 //        for (Class<?> i : something.getClasses()) {
 //            System.out.println("##@ 2 : "+i);

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspect.aj
@@ -350,11 +350,12 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
      *
      * @param actor the Actor returned by the {@code Creator.create()} method
      * */
-    after() returning(final Actor actor) : Pointcuts.actorCreator() {
+    Actor around() : Pointcuts.actorCreator() {
+        final Actor actor = proceed();
         final String className = actor.getClass().getCanonicalName();
         final ActorPath actorPath = actor.self().path();
         final PathAndClass pac = new PathAndClass(actorPath, Option.apply(className));
-        if (this.pathTags.containsKey(actorPath)) return; // the key is there, we need do nothing.
+        if (this.pathTags.containsKey(actorPath)) return actor; // the key is there, we need do nothing.
         // add the path -> type pair to the pathTags map
         this.pathTags.putIfAbsent(actorPath, className);
 
@@ -371,6 +372,7 @@ public aspect ActorCellMonitoringAspect extends AbstractMonitoringAspect issingl
             final int currentNumberOfActors = this.numberOfActors.get(this.anonymousActorClassName).decrementAndGet();
             this.counterInterface.recordGaugeValue(Aspects.actorCount(), currentNumberOfActors, getTags(actorPath, this.anonymousActorClassName));
         }
+        return actor;
     }
 
 }

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -72,7 +72,7 @@ abstract aspect Pointcuts {
     static pointcut actorCellInternalStop(ActorCell actorCell) : target(actorCell) && execution(* akka.actor.ActorCell.stop());
 
     /**
-     * Pointcut for {@code ???} method in akka's java api, extracting the Actor used to construct the {@code Creator}
+     * Pointcut for {@code Creator.create()} method in akka's java api. We use `returning(Actor actor)` to extract the actor
      * */
-    static pointcut actorCreator(Creator creator) : target(creator) && call(* akka.japi.Creator.create());
+    static pointcut actorCreator() : call(* akka.japi.Creator.create());
  }

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -74,5 +74,5 @@ abstract aspect Pointcuts {
     /**
      * Pointcut for {@code Creator.create()} method in akka's java api. We use `returning(Actor actor)` to extract the actor
      * */
-    static pointcut actorCreator() : call(* akka.japi.Creator.create());
+    static pointcut actorCreator() : call(* akka.japi.Creator+.create());
  }

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -73,6 +73,9 @@ abstract aspect Pointcuts {
 
     /**
      * Pointcut for {@code Creator.create()} method in akka's java api. We use `returning(Actor actor)` to extract the actor
+     *
+     * We specify the return type as 'Actor', to avoid catching the creators that return 'typed' actors (i.e. this pointcut
+     * is strictly for catching those actors that would otherwise have anonymous type elsewhere in the runtime)
      * */
-    static pointcut actorCreator() : call(Actor akka.japi.Creator.create());
+    static pointcut actorCreator() : call(Actor akka.japi.Creator+.create());
  }

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -15,9 +15,11 @@
  */
 package org.eigengo.monitor.agent.akka;
 
+import akka.actor.Actor;
 import akka.actor.ActorCell;
 import akka.actor.ActorRef;
 import akka.actor.Props;
+import akka.japi.Creator;
 
 /**
  * Centralises the pointcuts
@@ -68,4 +70,9 @@ abstract aspect Pointcuts {
      * Pointcut for {@code ActorCell.stop()} method, extracting the targeted {@code ActorCell}
      */
     static pointcut actorCellInternalStop(ActorCell actorCell) : target(actorCell) && execution(* akka.actor.ActorCell.stop());
-}
+
+    /**
+     * Pointcut for {@code ???} method in akka's java api, extracting the Actor used to construct the {@code Creator}
+     * */
+    static pointcut actorCreator(Creator creator) : target(creator) && call(* akka.japi.Creator.create());
+ }

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -15,7 +15,6 @@
  */
 package org.eigengo.monitor.agent.akka;
 
-import akka.actor.Actor;
 import akka.actor.ActorCell;
 import akka.actor.ActorRef;
 import akka.actor.Props;

--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -15,6 +15,7 @@
  */
 package org.eigengo.monitor.agent.akka;
 
+import akka.actor.Actor;
 import akka.actor.ActorCell;
 import akka.actor.ActorRef;
 import akka.actor.Props;
@@ -49,12 +50,12 @@ abstract aspect Pointcuts {
      * it in the {@code after returning()} advices.
      */
     private static pointcut unnamedActorOf(Props props) :
-            execution(* akka.actor.ActorRefFactory+.actorOf(*)) && args(props);
+            execution(ActorRef akka.actor.ActorRefFactory+.actorOf(*)) && args(props);
     /**
      * Pointcut for the {@code actorOf} method in {@code ActorRefFactory} implementations where actor is named on creation
      */
     private static pointcut namedActorOf(Props props) :
-            execution(* akka.actor.ActorRefFactory+.actorOf(*,*)) && args(props, *);
+            execution(ActorRef akka.actor.ActorRefFactory+.actorOf(*,*)) && args(props, *);
     /**
      * Public pointcut for retrieving Props instance used by {@code actorOf} method in {@code ActorRefFactory}
      */
@@ -73,5 +74,5 @@ abstract aspect Pointcuts {
     /**
      * Pointcut for {@code Creator.create()} method in akka's java api. We use `returning(Actor actor)` to extract the actor
      * */
-    static pointcut actorCreator() : call(* akka.japi.Creator+.create());
+    static pointcut actorCreator() : call(Actor akka.japi.Creator.create());
  }

--- a/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
+++ b/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
@@ -75,14 +75,11 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
     }
 
     public class InnerActor extends UntypedActor {
-        UUID id;
+        private final UUID id;
         InnerActor(UUID uuid) {this.id = uuid;}
 
         public void onReceive(Object message) {
-            if (message instanceof UUID) {
-                this.id = (UUID)message;
-            }
-            sender().tell(id, self());
+            /* noop */
         }
     }
 
@@ -133,10 +130,10 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
         this.unnamedGreetPrinter = system.actorOf(this.unnamedGreetPrinterProps);
 
         this.outerActorProps = new Props(new UntypedActorFactory() {
-                    public UntypedActor create() {
-                        return new OuterActor();
-                    }
-                });
+            public UntypedActor create() {
+                return new OuterActor();
+            }
+        });
         this.outerActor = system.actorOf(this.outerActorProps);
 
         this.innerActorProps = new Props(new UntypedActorFactory() {

--- a/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
+++ b/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
@@ -97,11 +97,13 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
     protected final Props greetPrinterProps;
     protected final Props unnamedGreetPrinterProps;
     protected final Props outerActorProps;
+    protected final Props innerActorProps;
     // The following fields are the ActorRefs constructed using the Props above
     protected final ActorRef greeter;
     protected final ActorRef greetPrinter;
     protected final ActorRef unnamedGreetPrinter;
     protected final ActorRef outerActor;
+    protected final ActorRef innerActor;
 
     /**
      * Constructs the ActorSystem under test, and creates the Props and ActorRefs above
@@ -140,6 +142,13 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
                     }
                 });
         this.outerActor = system.actorOf(this.outerActorProps);
+
+        this.innerActorProps = new Props(new UntypedActorFactory() {
+            public InnerActor create() {
+                return new InnerActor(UUID.randomUUID());
+            }
+        });
+        this.innerActor = system.actorOf(innerActorProps);
 
     }
 

--- a/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
+++ b/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
@@ -68,7 +68,7 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
     public class OuterActor extends UntypedActor {
 
         public void onReceive(final Object message) {
-            if (message instanceof UUID) {
+            if (message instanceof UUID) {   // The actors created here have anonymous tags with current monitoring
                 getContext().actorOf(new Props(new UntypedActorFactory() {
                     public InnerActor create() {
                         return new InnerActor((UUID)message);

--- a/agent-akka/src/test/resources/META-INF/monitor/JavaApi.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/JavaApi.conf
@@ -1,4 +1,5 @@
 {
     includeRoutees: true
-    included : [ "akka://javaapi/user/greetPrinter", "akka://javaapi/user/greeter" ]
+    included : [ "akka://javaapi/user/*", "akka://javaapi/user/*/*" ]
+    excludeAllNotIncluded: true
 }

--- a/agent-akka/src/test/resources/META-INF/monitor/JavaApi.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/JavaApi.conf
@@ -1,5 +1,4 @@
 {
     includeRoutees: true
     included : [ "akka://javaapi/user/greetPrinter", "akka://javaapi/user/greeter" ]
-    excluded : [ "akka://javaapi/user/*" ]
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspectSpec.scala
@@ -38,7 +38,7 @@ trait ActorCellMonitoringTaggingConvention {
    * @return the tags
    */
   def getTags(ref: ActorRef, props: Props, routees: Int = 0): List[String] =
-    /*getPathTags(ref, routees) ++ */getTypeTags(ref, props)
+    getPathTags(ref, routees) ++ getTypeTags(ref, props)
 
   /**
    * Gets the path tags for the given ``ref`` and ``routees``.

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/ActorCellMonitoringAspectSpec.scala
@@ -38,7 +38,7 @@ trait ActorCellMonitoringTaggingConvention {
    * @return the tags
    */
   def getTags(ref: ActorRef, props: Props, routees: Int = 0): List[String] =
-    getPathTags(ref, routees) ++ getTypeTags(ref, props)
+    /*getPathTags(ref, routees) ++ */getTypeTags(ref, props)
 
   /**
    * Gets the path tags for the given ``ref`` and ``routees``.

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/CountFilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/CountFilteredActorCellMonitoringAspectSpec.scala
@@ -11,6 +11,7 @@ class CountFilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspe
   "Actor count monitoring" should {
 
     "Not record the count of exluded actors" in {
+      TestCounterInterface.clear()
       withActorsOf(Props[SimpleActor], Props[KillableActor]) { (monitored, unmonitored) =>
         val counterBeforeKill = TestCounterInterface.foldlByAspect(actorCount)(takeLHS)
         counterBeforeKill.size === 1

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/CountFilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/CountFilteredActorCellMonitoringAspectSpec.scala
@@ -26,5 +26,10 @@ class CountFilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspe
         counterAfterKill must contain(TestCounter(actorCount, 0, monitored.tags))
       }
     }
+
+    "Shutdown system" in {
+      system.shutdown()
+      success
+    }
   }
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -38,12 +38,6 @@ class JavaApiActorCellMonitoringAspectSpec
     val outerActorTypeTag = s"akka.type:javaapi.${classOf[OuterActor].getCanonicalName}"
     val innerActorTypeTag = s"akka.type:javaapi.${classOf[InnerActor].getCanonicalName}"
 
-    def tagsContain(tags: Seq[String], check: String): MatchResult[Any] = {
-      val doesContain = tags.exists(_.contains(check))
-      if (!doesContain) println("TEST FAILURE: "+tags + "\n doesn't contain\n  "+check)
-      doesContain === true
-    }
-
     implicit class PimpedTestCounters(testCounters: List[TestCounter]) {
 
       def containsCounters(aspect:String, counters: Seq[(Int, String)]): MatchResult[Any] = {
@@ -108,12 +102,13 @@ class JavaApiActorCellMonitoringAspectSpec
 
     "Record messages sent to an ActorSelection" in {
       TestCounterInterface.clear()
-            val innerActorSelection = system.actorSelection("javaapi/user/$b/$e")
+            val innerActorSelection = system.actorSelection("/javaapi/user/$b/$a")
             innerActorSelection.tell(1, ActorRef.noSender)
       Thread.sleep(1000L)
 
-      TestCounterInterface.foldlByAspect(delivered(1: Int))(TestCounter.plus) must containAllOf(Seq(
-        TestCounter(delivered(1: Int), 1, innerActorTags)))
+      TestCounterInterface.foldlByAspect(delivered(1: Int))(TestCounter.plus)containsCounters (delivered(1: Int), Seq(
+        (1, innerActorTypeTag)
+      ))
     }.pendingUntilFixed("this may just be failing because of actor selection syntax. This isn't needed atm, but is a test we should have for completeness")
 
     "Record actor death" in {

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -56,14 +56,6 @@ class JavaApiActorCellMonitoringAspectSpec
 
     }
 
-
-    "Tag actors with appropriate names" in {
-      greetPrinterTypeTag.contains("GreetPrinter")
-      greeterTypeTag.contains("Greeter")
-      outerActorTypeTag.contains("OuterActor")
-      innerActorTypeTag.contains("InnerActor")
-    }
-
     // records the count of actors, grouped by simple class name
     "Record the actor creation" in {
 

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -61,6 +61,7 @@ class JavaApiActorCellMonitoringAspectSpec
 
       Thread.sleep(100L)
       val createdCounters = TestCounterInterface.foldlByAspect(actorCount)(takeLHS)
+      println(createdCounters)
       createdCounters containsCounters(actorCount, Seq(
         (2, greetPrinterTypeTag),  // one named, one unnamed.
         (1, greeterTypeTag),

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -44,13 +44,13 @@ class JavaApiActorCellMonitoringAspectSpec
         counters.foldLeft(true){(b, counter) =>
           val aspectIsFine = testCounters.filter(_.aspect == aspect)
           val tagIsFine = aspectIsFine.filter(_.tags.contains(counter._2))
-          val valueIsFine = tagIsFine.filter(_.value == counter._1)
+          val valueIsFine = tagIsFine.headOption
 
-        if (aspectIsFine.isEmpty) println("Failure: no corresponding aspect:  "+aspect)
+        if (aspectIsFine.isEmpty) println(s"Failure: no corresponding aspect: $aspect\n Found: ${testCounters.map(_.aspect).toSet} ")
         if (!aspectIsFine.isEmpty && tagIsFine.isEmpty) println(s"Failure: no corresponding tag: ${counter._2}\n Found: $aspectIsFine")
-        if (!tagIsFine.isEmpty && valueIsFine.isEmpty) println(s"Failure: wrong value for tag ${counter._2}, expected: ${counter._1}\n Found ${tagIsFine.map(_.value)}")
+        if (!tagIsFine.isEmpty && valueIsFine.get.value != counter._1) println(s"Failure: wrong value for tag ${counter._2}, expected: ${counter._1}\n Found ${tagIsFine.map(_.value)}")
 
-          !valueIsFine.isEmpty
+          valueIsFine.get.value == counter._1
         } must beTrue
       }
 
@@ -70,7 +70,7 @@ class JavaApiActorCellMonitoringAspectSpec
       Thread.sleep(100L)
       val createdCounters = TestCounterInterface.foldlByAspect(actorCount)(takeLHS)
       createdCounters containsCounters(actorCount, Seq(
-        (1, greetPrinterTypeTag),
+        (2, greetPrinterTypeTag),  // one named, one unnamed.
         (1, greeterTypeTag),
         (1, outerActorTypeTag),
         (1, innerActorTypeTag)))
@@ -84,7 +84,7 @@ class JavaApiActorCellMonitoringAspectSpec
       Thread.sleep(1000L)
       val testCounters: List[TestCounter] = TestCounterInterface.foldlByAspect(actorCount)(takeLHS)
       testCounters containsCounters(actorCount, Seq(
-        (1, greetPrinterTypeTag),
+        (2, greetPrinterTypeTag),
         (1, greeterTypeTag),
         (1, outerActorTypeTag),
         (6, innerActorTypeTag)))

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -33,16 +33,10 @@ class JavaApiActorCellMonitoringAspectSpec
   "Counting the number of actors using the java api" should {
     configure("JavaApi.conf")
 
-    val outerActorTypeTag = s"akka.type:javaapi.${classOf[OuterActor].getCanonicalName}" //org.eigengo.monitor.agent.akka.AbstractJavaApiActorCellMonitoringAspectSpec.OuterActor"
-    val innerActorTypeTag = s"akka.type:javaapi.${classOf[InnerActor].getCanonicalName}"//org.eigengo.monitor.agent.akka.AbstractJavaApiActorCellMonitoringAspectSpec.InnerActor"
     val greetPrinterTypeTag = s"akka.type:javaapi.${classOf[GreetPrinter].getCanonicalName}"
     val greeterTypeTag = s"akka.type:javaapi.${classOf[Greeter].getCanonicalName}"
-
-    val unnamedGreetPrinterTags = getTags(unnamedGreetPrinter, unnamedGreetPrinterProps)
-    val namedGreetPrinterTags = getTags(greetPrinter, greetPrinterProps)
-    val greeterTags = getTags(greeter, greeterProps)
-    val outerActorTags = List(outerActorTypeTag)
-    val innerActorTags = List("akka.path:/javaapi/user/$c",innerActorTypeTag)  // TODO: Robustness of tests :p
+    val outerActorTypeTag = s"akka.type:javaapi.${classOf[OuterActor].getCanonicalName}"
+    val innerActorTypeTag = s"akka.type:javaapi.${classOf[InnerActor].getCanonicalName}"
 
     def tagsContain(tags: Seq[String], check: String): MatchResult[Any] = {
       val doesContain = tags.exists(_.contains(check))
@@ -70,11 +64,10 @@ class JavaApiActorCellMonitoringAspectSpec
 
 
     "Tag actors with appropriate names" in {
-      tagsContain(unnamedGreetPrinterTags, "GreetPrinter")
-      tagsContain(namedGreetPrinterTags, "GreetPrinter")
-      tagsContain(greeterTags, "Greeter")
-      tagsContain(outerActorTags, "OuterActor")
-      tagsContain(innerActorTags, "InnerActor")
+      greetPrinterTypeTag.contains("GreetPrinter")
+      greeterTypeTag.contains("Greeter")
+      outerActorTypeTag.contains("OuterActor")
+      innerActorTypeTag.contains("InnerActor")
     }
 
     // records the count of actors, grouped by simple class name
@@ -108,8 +101,9 @@ class JavaApiActorCellMonitoringAspectSpec
       innerActor ! 1
       Thread.sleep(1000L)
 
-      TestCounterInterface.foldlByAspect(delivered(1: Int))(TestCounter.plus) must containAllOf(Seq(
-        TestCounter(delivered(1: Int), 1, innerActorTags)))
+      TestCounterInterface.foldlByAspect(delivered(1: Int))(TestCounter.plus) containsCounters (delivered(1: Int), Seq(
+        (1, innerActorTypeTag)
+      ))
     }
 
     "Record messages sent to an ActorSelection" in {

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -35,15 +35,20 @@ class JavaApiActorCellMonitoringAspectSpec
     val greeterTags = getTags(greeter, greeterProps)
     val outerActorTags = getTags(outerActor, outerActorProps)
     val innerActorTags = getTags(innerActor, innerActorProps)
+
     // records the count of actors, grouped by simple class name
     "Record the actor creation, and let us exclude an unnamed anonymous inner class actor" in {
 
       Thread.sleep(100L)
-      TestCounterInterface.foldlByAspect(actorCount)(takeLHS) must containAllOf(Seq(
+      val createdCounters = TestCounterInterface.foldlByAspect(actorCount)(takeLHS)
+      createdCounters must containAllOf(Seq(
         TestCounter(actorCount, 1, unnamedGreetPrinterTags),
         TestCounter(actorCount, 1, namedGreetPrinterTags),
         TestCounter(actorCount, 1, greeterTags),
         TestCounter(actorCount, 1, outerActorTags)))
+
+      createdCounters must not contain TestCounter(actorCount, 1, unnamedGreetPrinterTags)
+
 
     }
 

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -58,7 +58,6 @@ class JavaApiActorCellMonitoringAspectSpec
 
     // records the count of actors, grouped by simple class name
     "Record the actor creation" in {
-      TestCounterInterface.clear()
       Thread.sleep(100L)
       val createdCounters = TestCounterInterface.foldlByAspect(actorCount)(takeLHS)
       createdCounters containsCounters(actorCount, Seq(

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -58,10 +58,9 @@ class JavaApiActorCellMonitoringAspectSpec
 
     // records the count of actors, grouped by simple class name
     "Record the actor creation" in {
-
+      TestCounterInterface.clear()
       Thread.sleep(100L)
       val createdCounters = TestCounterInterface.foldlByAspect(actorCount)(takeLHS)
-      println(createdCounters)
       createdCounters containsCounters(actorCount, Seq(
         (2, greetPrinterTypeTag),  // one named, one unnamed.
         (1, greeterTypeTag),

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -50,7 +50,7 @@ class JavaApiActorCellMonitoringAspectSpec
         if (!aspectIsFine.isEmpty && tagIsFine.isEmpty) println(s"Failure: no corresponding tag: ${counter._2}\n Found: $aspectIsFine")
         if (!tagIsFine.isEmpty && valueIsFine.get.value != counter._1) println(s"Failure: wrong value for tag ${counter._2}, expected: ${counter._1}\n Found ${tagIsFine.map(_.value)}")
 
-          valueIsFine.get.value == counter._1
+          valueIsFine.map(_.value) == Some(counter._1)
         } must beTrue
       }
 

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/PathFilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/PathFilteredActorCellMonitoringAspectSpec.scala
@@ -51,6 +51,11 @@ class PathFilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspec
       counter.value mustEqual 1
       counter.tags must contain(getPathTags(a, 0).head)
     }
+
+    "Shutdown system" in {
+      system.shutdown()
+      success
+    }
   }
 
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/SamplingActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/SamplingActorCellMonitoringAspectSpec.scala
@@ -68,6 +68,11 @@ class SamplingActorCellMonitoringAspectSpec extends ActorCellMonitoringAspectSpe
       counter3(0).value mustEqual 1004
       counter3.size === 251
     }
+
+    "Shutdown system" in {
+      system.shutdown()
+      success
+    }
   }
 
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/TypeFilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/TypeFilteredActorCellMonitoringAspectSpec.scala
@@ -84,6 +84,11 @@ class TypeFilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspec
       val monitoredIntegerMessages = TestCounterInterface.foldlByAspect(delivered(1: Int))(TestCounter.plus)
       monitoredIntegerMessages.size === 0
     }
+
+    "Shutdown system" in {
+      system.shutdown()
+      success
+    }
   }
 
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
@@ -165,6 +165,11 @@ class UnfilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspectS
         c1Counter.value mustEqual 1
       }
     }
+
+    "Shutdown system" in {
+      system.shutdown()
+      success
+    }
   }
 
 }

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/UnfilteredActorCellMonitoringAspectSpec.scala
@@ -39,6 +39,7 @@ class UnfilteredActorCellMonitoringAspectSpec extends ActorCellMonitoringAspectS
 
     // records the count of actors, grouped by simple class name
     "Record the actor count" in {
+      TestCounterInterface.clear()
       withActorOf(Props[SimpleActor]) { ca =>
         TestCounterInterface.foldlByAspect(actorCount, ContainsTag(ca.pathTag))(takeLHS) must contain(TestCounter(actorCount, 1, ca.tags))
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -33,7 +33,7 @@ object BuildSettings {
         "Spray Releases" at "http://repo.spray.io",
         "Spray Nightlies" at "http://nightlies.spray.io"
       ),
-      parallelExecution in Test := true
+      parallelExecution in Test := false
   )
 
   lazy val aspectjCompileSettings = aspectjSettings ++ Seq(

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -33,7 +33,7 @@ object BuildSettings {
         "Spray Releases" at "http://repo.spray.io",
         "Spray Nightlies" at "http://nightlies.spray.io"
       ),
-      parallelExecution in Test := false
+      parallelExecution in Test := true
   )
 
   lazy val aspectjCompileSettings = aspectjSettings ++ Seq(


### PR DESCRIPTION
Issue #89 

This pr emulates the failure case, where an Actor is created via the japi.Creator interface and has no visible type during runtime. It provides a treatment of the case, and an associated test suite.

In addition, since the current assumption is that only implementations of that interface which return a 'generic' Actor class leave the actor type inaccessible during runtime, this pr also updates sampling and actor count so that we sample and count actors 'per type'. We _still_ apply path filters (for sampling) to any cases this doesn't catch, and still record their actor count; however, we will count all remaining generic/anonymous actors as being of one type. 

ActorCellMonitoringAspect is now final, because the reference hash maps it contains are non-static. This may implement a serious misunderstanding, and should be considered a potential bug.

If the number of untyped actors in a monitored system is generally non-zero, this indicates that there is another creation point for such generic actors we're still not catching, or actors we're catching that we shouldn't, and should be reported as a bug (or that there are 'race conditions' or other weirdness in the execution code and pointcut logic isn't enough, in which case it should be reported as a very difficult bug).

The failing TravisCI test 'CountFilteredActorCellMonitoringAspectSpec' is succeeding on one of my machines (iMac + OSX) but failing on my other (Thinkpad + Ubuntu), so I do have some traction on it now. May be the vdb...
