### PR TITLE
enable japi.Creator pointcut

### DIFF
--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/Pointcuts.aj
@@ -15,9 +15,11 @@
  */
 package org.eigengo.monitor.agent.akka;
 
+import akka.actor.Actor;
 import akka.actor.ActorCell;
 import akka.actor.ActorRef;
 import akka.actor.Props;
+import akka.japi.Creator;
 
 /**
  * Centralises the pointcuts

--- a/agent-akka/src/test/resources/META-INF/aop.xml
+++ b/agent-akka/src/test/resources/META-INF/aop.xml
@@ -7,6 +7,7 @@
     <weaver options="-verbose -XnoInline -showWeaveInfo">
         <include within="akka.actor.*"/>
         <include within="akka.event.*"/>
+        <include within="akka.japi.*"/>
     </weaver>
 
 </aspectj>


### PR DESCRIPTION
Without the imports and the weaver options, the japi.Creator code is inactive
