### PR TITLE
Flip includeRoutees to false in examples

### DIFF
--- a/agent-akka/src/test/resources/META-INF/monitor/CountFiltered.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/CountFiltered.conf
@@ -1,4 +1,4 @@
 {
-    includeRoutees: true
+    includeRoutees: false
     excluded: [ "akka:*.org.eigengo.monitor.agent.akka.KillableActor" ]
 }

--- a/agent-akka/src/test/resources/META-INF/monitor/JavaApi.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/JavaApi.conf
@@ -1,5 +1,5 @@
 {
-    includeRoutees: true
+    includeRoutees: false
     included : [ "akka://javaapi/user/*", "akka://javaapi/user/*/*" ]
     excludeAllNotIncluded: true
 }

--- a/agent-akka/src/test/resources/META-INF/monitor/PathFiltered.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/PathFiltered.conf
@@ -1,5 +1,5 @@
 {
-    includeRoutees: true
+    includeRoutees: false
     excludeAllNotIncluded: true
     included: [ "akka://default/user/a" ]
 }

--- a/agent-akka/src/test/resources/META-INF/monitor/TypeFiltered.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/TypeFiltered.conf
@@ -1,5 +1,5 @@
 {
-    includeRoutees: true
+    includeRoutees: false
     excludeAllNotIncluded: true
     included: [
         "akka:default.org.eigengo.monitor.agent.akka.SimpleActor",

--- a/agent-akka/src/test/resources/META-INF/monitor/Unfiltered.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/Unfiltered.conf
@@ -1,3 +1,3 @@
 {
-    includeRoutees: true
+    includeRoutees: false
 }

--- a/agent-akka/src/test/resources/META-INF/monitor/agent.conf
+++ b/agent-akka/src/test/resources/META-INF/monitor/agent.conf
@@ -5,6 +5,6 @@ org.eigengo.monitor.agent {
 
 
     akka {
-        includeRoutees: true
+        includeRoutees: false
     }
 }

--- a/docs/rst/agents/akka.rst
+++ b/docs/rst/agents/akka.rst
@@ -113,7 +113,7 @@ configuration file at ``META-INF/monitor/agent.conf``. The configuration file mu
         }
 
         akka {
-            includeRoutees: true
+            includeRoutees: false
             included: [
                 "akka:*.com.company.project.module.TypeOfActor"
             ]

--- a/example-akka/src/main/resources/META-INF/monitor/agent.conf
+++ b/example-akka/src/main/resources/META-INF/monitor/agent.conf
@@ -4,7 +4,7 @@ org.eigengo.monitor.agent {
     }
 
     akka {
-        includeRoutees: true
+        includeRoutees: false
     }
 
 }


### PR DESCRIPTION
This will avoid the creation of a large number of tags by default in Datadog

@janm399 does this make sense?
