### PR TITLE
Twothree

### DIFF
--- a/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
+++ b/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
@@ -16,6 +16,8 @@
 package org.eigengo.monitor.agent.akka;
 
 import akka.actor.*;
+import akka.japi.Creator;
+import scala.collection.immutable.List;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -65,11 +67,7 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
 
         public void onReceive(final Object message) {
             if (message instanceof UUID) {   // The actors created here have anonymous tags with current monitoring
-                getContext().actorOf(new Props(new UntypedActorFactory() {
-                    public InnerActor create() {
-                        return new InnerActor((UUID)message);
-                    }
-                }));
+                getContext().actorOf(Props.create(InnerActor.class, message));
             }
         }
     }
@@ -132,7 +130,8 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
         this.unnamedGreetPrinterProps = Props.create(GreetPrinter.class);
         this.unnamedGreetPrinter = system.actorOf(this.unnamedGreetPrinterProps);
 
-        // Deprecated API usage is OK: we need to ensure that even old code remains monitorable
+        // Deprecated API usage is no longer OK: we need to ensure that even old code remains monitorable
+        /*
         this.outerActorProps = new Props(new UntypedActorFactory() {
             public UntypedActor create() {
                 return new OuterActor();
@@ -147,7 +146,12 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
             }
         });
         this.innerActor = system.actorOf(innerActorProps);
+        */
 
+        this.outerActorProps = Props.create(OuterActor.class);
+        this.outerActor = system.actorOf(this.outerActorProps);
+        this.innerActorProps = Props.create(InnerActor.class, UUID.randomUUID());
+        this.innerActor = system.actorOf(innerActorProps);
     }
 
 }

--- a/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
+++ b/agent-akka/src/test/java/org/eigengo/monitor/agent/akka/AbstractJavaApiActorCellMonitoringAspectSpec.java
@@ -63,7 +63,7 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
         }
     }
 
-    public class OuterActor extends UntypedActor {
+    public static class OuterActor extends UntypedActor {
 
         public void onReceive(final Object message) {
             if (message instanceof UUID) {   // The actors created here have anonymous tags with current monitoring
@@ -72,7 +72,7 @@ abstract class AbstractJavaApiActorCellMonitoringAspectSpec {
         }
     }
 
-    public class InnerActor extends UntypedActor {
+    public static class InnerActor extends UntypedActor {
 
         // unused parameter OK
         InnerActor(UUID ignored) {

--- a/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
+++ b/agent-akka/src/test/scala/org/eigengo/monitor/agent/akka/JavaApiActorCellMonitoringAspectSpec.scala
@@ -20,7 +20,8 @@ import org.specs2.mutable.SpecificationLike
 import java.util.UUID
 import akka.actor.ActorRef
 import org.specs2.matcher.MatchResult
-import org.eigengo.monitor.agent.akka.AbstractJavaApiActorCellMonitoringAspectSpec.{Greeter, GreetPrinter}
+import org.eigengo.monitor.agent.akka.AbstractJavaApiActorCellMonitoringAspectSpec._
+import scala.Some
 
 class JavaApiActorCellMonitoringAspectSpec
   extends AbstractJavaApiActorCellMonitoringAspectSpec
@@ -90,17 +91,6 @@ class JavaApiActorCellMonitoringAspectSpec
         (1, innerActorTypeTag)
       ))
     }
-
-    "Record messages sent to an ActorSelection" in {
-      TestCounterInterface.clear()
-            val innerActorSelection = system.actorSelection("/javaapi/user/$b/$a")
-            innerActorSelection.tell(1, ActorRef.noSender)
-      Thread.sleep(1000L)
-
-      TestCounterInterface.foldlByAspect(delivered(1: Int))(TestCounter.plus)containsCounters (delivered(1: Int), Seq(
-        (1, innerActorTypeTag)
-      ))
-    }.pendingUntilFixed("this may just be failing because of actor selection syntax. This isn't needed atm, but is a test we should have for completeness")
 
     "Record actor death" in {
       TestCounterInterface.clear()

--- a/example-akka/src/main/scala/org/eigengo/monitor/example/akka/Main.scala
+++ b/example-akka/src/main/scala/org/eigengo/monitor/example/akka/Main.scala
@@ -16,7 +16,7 @@
 package org.eigengo.monitor.example.akka
 
 import akka.actor.{ActorRef, Props, ActorSystem, Actor}
-import akka.routing.RoundRobinRouter
+import akka.routing.RoundRobinPool
 
 // run with -javaagent:$HOME/.m2/repository/org/aspectj/aspectjweaver/1.7.3/aspectjweaver-1.7.3.jar
 // in my case -javaagent:/Users/janmachacek/.m2/repository/org/aspectj/aspectjweaver/1.7.3/aspectjweaver-1.7.3.jar
@@ -47,7 +47,7 @@ object Main extends App {
   }
 
   val system = ActorSystem()
-  val bar = system.actorOf(Props[BarActor].withRouter(RoundRobinRouter(nrOfInstances = 10)), "bar")
+  val bar = system.actorOf(Props[BarActor].withRouter(RoundRobinPool(nrOfInstances = 10)), "bar")
   val foo = system.actorOf(Props(new FooActor(bar)), "foo")
   val CountPattern = "(\\d+)".r
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val aspectj_weaver = "org.aspectj"  % "aspectjweaver" % aspectj_version
 
   object akka {
-    val akka_version = "2.2.1"
+    val akka_version = "2.3.2"
 
     val actor   = "com.typesafe.akka" %% "akka-actor"   % akka_version
     val testkit = "com.typesafe.akka" %% "akka-testkit" % akka_version
@@ -28,16 +28,16 @@ object Dependencies {
   }
 
   object spray {
-    val spray_version = "1.2-RC2"
+    val spray_version = "1.3.1"
 
     val can   = "io.spray" % "spray-can"   % spray_version
     val http  = "io.spray" % "spray-http"  % spray_version
     val httpx = "io.spray" % "spray-httpx" % spray_version
   }
 
-  val typesafe_config  = "com.typesafe"	        % "config"                % "1.0.2"
+  val typesafe_config  = "com.typesafe"         % "config"                % "1.2.0"
   val dogstatsd_client = "com.indeed"           % "java-dogstatsd-client" % "2.0.7"
   val codahale_metrics = "com.codahale.metrics" % "metrics-core"          % "3.0.1"
 
-  val specs2           = "org.specs2"        %% "specs2"                % "2.2.3"
+  val specs2           = "org.specs2"          %% "specs2"                % "2.3.11"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   }
 
   object play {
-    val test    = "com.typesafe.play" %% "play-test" % "2.2.1"
+    val test    = "com.typesafe.play" %% "play-test" % "2.3-SNAPSHOT"
   }
 
   object spray {

--- a/project/MonitorBuild.scala
+++ b/project/MonitorBuild.scala
@@ -5,8 +5,8 @@ object MonitorBuild extends Build {
 
   override val settings = super.settings ++ Seq(
     organization := "org.eigengo.monitor",
-    version := "0.3-SNAPSHOT",
-    scalaVersion := "2.10.2"
+    version := "0.4-SNAPSHOT",
+    scalaVersion := "2.10.4"
   )
 
   def module(dir: String, extraSettings: Seq[Setting[_]] = Nil) = Project(id = dir, base = file(dir), 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,6 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.3.2")
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0-SNAPSHOT")
-
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")


### PR DESCRIPTION
This brings monitoring to Akka 2.3: it removes deprecated code, and includes Play 2.3-SNAPSHOT.

It also fixes the failing tests in `master`. If all works well, this will become the `0.4-SNAPSHOT` release.
