### PR TITLE
Added outline of the dtrace output

### DIFF
--- a/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/AbstractMonitoringAspect.aj
+++ b/agent-akka/src/main/aspectj/org/eigengo/monitor/agent/akka/AbstractMonitoringAspect.aj
@@ -30,8 +30,10 @@ abstract aspect AbstractMonitoringAspect {
             CounterInterface counterInterface = (CounterInterface)Class.forName(configuration.counterInterfaceClassName()).newInstance();
             return counterInterface;
         } catch (final ReflectiveOperationException e) {
+            e.printStackTrace();
             return new NullCounterInterface();
         } catch (final ClassCastException e) {
+            e.printStackTrace();
             return new NullCounterInterface();
         }
     }

--- a/example-akka/src/main/resources/META-INF/monitor/agent.conf
+++ b/example-akka/src/main/resources/META-INF/monitor/agent.conf
@@ -1,6 +1,6 @@
 org.eigengo.monitor.agent {
     output {
-        class: "org.eigengo.monitor.output.statsd.StatsdCounterInterface"
+        class: "org.eigengo.monitor.output.dtrace.DtraceCounterInterface"
     }
 
     akka {

--- a/example-akka/src/main/scala/org/eigengo/monitor/example/akka/Main.scala
+++ b/example-akka/src/main/scala/org/eigengo/monitor/example/akka/Main.scala
@@ -18,8 +18,8 @@ package org.eigengo.monitor.example.akka
 import akka.actor.{ActorRef, Props, ActorSystem, Actor}
 import akka.routing.RoundRobinPool
 
-// run with -javaagent:$HOME/.m2/repository/org/aspectj/aspectjweaver/1.7.3/aspectjweaver-1.7.3.jar
-// in my case -javaagent:/Users/janmachacek/.m2/repository/org/aspectj/aspectjweaver/1.7.3/aspectjweaver-1.7.3.jar
+// run with -javaagent:$HOME/.ivy2/cache/org.aspectj/aspectjweaver/jars/aspectjweaver-1.7.4.jar
+// in my case -javaagent:/Users/janmachacek/.ivy2/cache/org.aspectj/aspectjweaver/jars/aspectjweaver-1.7.4.jar
 object Main extends App {
   val longSleep = 10
   val shortSleep = 1

--- a/output-dtrace/src/main/dtrace/MessageCount.d
+++ b/output-dtrace/src/main/dtrace/MessageCount.d
@@ -1,0 +1,3 @@
+akka$1:::message-counter {
+	printf("%s -> %d", stringof(copyin(arg0, arg1 + 1)), arg2);
+}

--- a/output-dtrace/src/main/dtrace/MessageCount.d
+++ b/output-dtrace/src/main/dtrace/MessageCount.d
@@ -1,3 +1,7 @@
-akka$1:::message-counter {
-	printf("%s -> %d", stringof(copyin(arg0, arg1 + 1)), arg2);
+akka$1:::all-counters {
+	printf("counter: %s -> %d", stringof(copyin(arg0, arg1 + 1)), arg2);
+}
+
+akka$1:::all-gauges {
+	printf("gauge: %s -> %d", stringof(copyin(arg0, arg1 + 1)), arg2);
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/Demo.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/Demo.java
@@ -1,0 +1,12 @@
+package org.eigengo.monitor.output.dtrace;
+
+public class Demo {
+
+    public static void main(String[] args) throws InterruptedException {
+        while (true) {
+            new DtraceCounterInterface().incrementCounter("akka://foo");
+            Thread.sleep(1000L);
+        }
+    }
+
+}

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
@@ -38,21 +38,17 @@ public class DtraceCounterInterface implements CounterInterface {
 
     @Override
     public void incrementCounter(String aspect, int delta, String... tags) {
-        provider.messageCount("+= " + aspect);
     }
 
     @Override
     public void decrementCounter(String aspect, String... tags) {
-        provider.messageCount("-- " + aspect);
     }
 
     @Override
     public void recordGaugeValue(String aspect, int value, String... tags) {
-        provider.messageCount("== " + aspect);
     }
 
     @Override
     public void recordExecutionTime(String aspect, int duration, String... tags) {
-        provider.messageCount(" t " + aspect);
     }
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2013 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eigengo.monitor.output.dtrace;
+
+import com.sun.tracing.ProviderFactory;
+import org.eigengo.monitor.output.CounterInterface;
+
+public class DtraceCounterInterface implements CounterInterface {
+
+    static DtraceCounterProvider provider;
+    static {
+        ProviderFactory factory = ProviderFactory.getDefaultFactory();
+        provider = factory.createProvider(DtraceCounterProvider.class);
+        provider.x(60);
+    }
+
+    @Override
+    public void incrementCounter(String aspect, String... tags) {
+        provider.foo("++ " + aspect);
+    }
+
+    @Override
+    public void incrementCounter(String aspect, int delta, String... tags) {
+        provider.foo("+= " + aspect);
+    }
+
+    @Override
+    public void decrementCounter(String aspect, String... tags) {
+        provider.foo("-- " + aspect);
+    }
+
+    @Override
+    public void recordGaugeValue(String aspect, int value, String... tags) {
+        provider.foo("== " + aspect);
+    }
+
+    @Override
+    public void recordExecutionTime(String aspect, int duration, String... tags) {
+        provider.foo(" t " + aspect);
+    }
+}

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
@@ -33,7 +33,7 @@ public class DtraceCounterInterface implements CounterInterface {
 
     @Override
     public void incrementCounter(String aspect, String... tags) {
-        provider.messageCount("++ " + aspect);
+        provider.messageCounter(aspect, aspect.length(), 1);
     }
 
     @Override

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
@@ -23,8 +23,13 @@ public class DtraceCounterInterface implements CounterInterface {
     static DtraceCounterProvider provider;
     static {
         ProviderFactory factory = ProviderFactory.getDefaultFactory();
+        System.out.println("***************** " + factory);
         provider = factory.createProvider(DtraceCounterProvider.class);
-        provider.x(60);
+        provider.goobledygook();
+    }
+
+    public void x() {
+
     }
 
     @Override

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
@@ -1,4 +1,4 @@
-/*
+    /*
  * Copyright (c) 2013 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@ public class DtraceCounterInterface implements CounterInterface {
         ProviderFactory factory = ProviderFactory.getDefaultFactory();
         System.out.println("***************** " + factory);
         provider = factory.createProvider(DtraceCounterProvider.class);
-        provider.goobledygook();
     }
 
     public void x() {
@@ -34,26 +33,26 @@ public class DtraceCounterInterface implements CounterInterface {
 
     @Override
     public void incrementCounter(String aspect, String... tags) {
-        provider.foo("++ " + aspect);
+        provider.messageCount("++ " + aspect);
     }
 
     @Override
     public void incrementCounter(String aspect, int delta, String... tags) {
-        provider.foo("+= " + aspect);
+        provider.messageCount("+= " + aspect);
     }
 
     @Override
     public void decrementCounter(String aspect, String... tags) {
-        provider.foo("-- " + aspect);
+        provider.messageCount("-- " + aspect);
     }
 
     @Override
     public void recordGaugeValue(String aspect, int value, String... tags) {
-        provider.foo("== " + aspect);
+        provider.messageCount("== " + aspect);
     }
 
     @Override
     public void recordExecutionTime(String aspect, int duration, String... tags) {
-        provider.foo(" t " + aspect);
+        provider.messageCount(" t " + aspect);
     }
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterInterface.java
@@ -33,22 +33,26 @@ public class DtraceCounterInterface implements CounterInterface {
 
     @Override
     public void incrementCounter(String aspect, String... tags) {
-        provider.messageCounter(aspect, aspect.length(), 1);
+        provider.counter(aspect, aspect.length(), 1);
     }
 
     @Override
     public void incrementCounter(String aspect, int delta, String... tags) {
+        provider.counter(aspect, aspect.length(), delta);
     }
 
     @Override
     public void decrementCounter(String aspect, String... tags) {
+        provider.counter(aspect, aspect.length(), -1);
     }
 
     @Override
     public void recordGaugeValue(String aspect, int value, String... tags) {
+        provider.gauge(aspect, aspect.length(), value);
     }
 
     @Override
     public void recordExecutionTime(String aspect, int duration, String... tags) {
+        provider.executionTime(aspect, aspect.length(), duration);
     }
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
@@ -21,7 +21,7 @@ import com.sun.tracing.dtrace.ModuleName;
 
 @ProviderName("akka")
 public interface DtraceCounterProvider extends com.sun.tracing.Provider {
-    @FunctionName("queueSize") void queueSize(int size);
-    @FunctionName("messageCounter") void messageCounter(String name, int length, int delta);
-    @FunctionName("receiveDuration") void receiveDuration(String name, int length, int duration);
+    @FunctionName("queue-size") void queueSize(int size);
+    @FunctionName("message-counter") void messageCounter(String name, int length, int delta);
+    @FunctionName("receive-duration") void receiveDuration(String name, int length, int duration);
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
@@ -21,13 +21,15 @@ import com.sun.tracing.dtrace.FunctionName;
 
 @ProviderName("akka")
 public interface DtraceCounterProvider extends com.sun.tracing.Provider {
-    @FunctionName("Records execution time of ``def receive``")
+    @FunctionName("Receive execution time")
     @ProbeName("execution-time")
     void executionTime(String name, int length, int duration);
 
-    @FunctionName("counter")
+    @FunctionName("All counters")
+    @ProbeName("all-counters")
     void counter(String name, int length, int delta);
 
-    @FunctionName("gauge")
+    @FunctionName("All gauges")
+    @ProbeName("all-gauges")
     void gauge(String name, int length, int value);
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2013 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eigengo.monitor.output.dtrace;
+
+import com.sun.tracing.ProviderName;
+import com.sun.tracing.dtrace.FunctionName;
+import com.sun.tracing.dtrace.ModuleName;
+
+@ProviderName("akka")
+@ModuleName("JSDT")
+public interface DtraceCounterProvider extends com.sun.tracing.Provider {
+    @FunctionName("foo") void foo(String name);
+    void x(int n);
+
+}

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
@@ -20,9 +20,7 @@ import com.sun.tracing.dtrace.FunctionName;
 import com.sun.tracing.dtrace.ModuleName;
 
 @ProviderName("akka")
-@ModuleName("JDST")
 public interface DtraceCounterProvider extends com.sun.tracing.Provider {
-    @FunctionName("foo") void foo(String name);
-    void goobledygook();
-
+    @FunctionName("messageCount") void messageCount(String name);
+    @FunctionName("queueSize") void queueSize(int size);
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
@@ -20,9 +20,9 @@ import com.sun.tracing.dtrace.FunctionName;
 import com.sun.tracing.dtrace.ModuleName;
 
 @ProviderName("akka")
-@ModuleName("JSDT")
+@ModuleName("JDST")
 public interface DtraceCounterProvider extends com.sun.tracing.Provider {
     @FunctionName("foo") void foo(String name);
-    void x(int n);
+    void goobledygook();
 
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
@@ -21,7 +21,7 @@ import com.sun.tracing.dtrace.ModuleName;
 
 @ProviderName("akka")
 public interface DtraceCounterProvider extends com.sun.tracing.Provider {
-    @FunctionName("messageCount") void messageCount(String name);
     @FunctionName("queueSize") void queueSize(int size);
     @FunctionName("messageCounter") void messageCounter(String name, int length, int delta);
+    @FunctionName("receiveDuration") void receiveDuration(String name, int length, int duration);
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
@@ -21,7 +21,7 @@ import com.sun.tracing.dtrace.ModuleName;
 
 @ProviderName("akka")
 public interface DtraceCounterProvider extends com.sun.tracing.Provider {
-    @FunctionName("queue-size") void queueSize(int size);
-    @FunctionName("message-counter") void messageCounter(String name, int length, int delta);
-    @FunctionName("receive-duration") void receiveDuration(String name, int length, int duration);
+    @FunctionName("execution-time") void executionTime(String name, int length, int duration);
+    @FunctionName("counter") void counter(String name, int length, int delta);
+    @FunctionName("gauge") void gauge(String name, int length, int value);
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
@@ -23,4 +23,5 @@ import com.sun.tracing.dtrace.ModuleName;
 public interface DtraceCounterProvider extends com.sun.tracing.Provider {
     @FunctionName("messageCount") void messageCount(String name);
     @FunctionName("queueSize") void queueSize(int size);
+    @FunctionName("messageCounter") void messageCounter(String name, int length, int delta);
 }

--- a/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
+++ b/output-dtrace/src/main/java/org/eigengo/monitor/output/dtrace/DtraceCounterProvider.java
@@ -15,13 +15,19 @@
  */
 package org.eigengo.monitor.output.dtrace;
 
+import com.sun.tracing.ProbeName;
 import com.sun.tracing.ProviderName;
 import com.sun.tracing.dtrace.FunctionName;
-import com.sun.tracing.dtrace.ModuleName;
 
 @ProviderName("akka")
 public interface DtraceCounterProvider extends com.sun.tracing.Provider {
-    @FunctionName("execution-time") void executionTime(String name, int length, int duration);
-    @FunctionName("counter") void counter(String name, int length, int delta);
-    @FunctionName("gauge") void gauge(String name, int length, int value);
+    @FunctionName("Records execution time of ``def receive``")
+    @ProbeName("execution-time")
+    void executionTime(String name, int length, int duration);
+
+    @FunctionName("counter")
+    void counter(String name, int length, int delta);
+
+    @FunctionName("gauge")
+    void gauge(String name, int length, int value);
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -12,9 +12,9 @@ object BuildSettings {
     ScalastylePlugin.Settings ++ 
     Seq(
       org.scalastyle.sbt.PluginKeys.config := file("project/scalastyle-config.xml"),
-      scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.7", "-deprecation", "-unchecked", "-Ywarn-dead-code"),
+      scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-unchecked", "-Ywarn-dead-code"),
       scalacOptions in (Compile, doc) <++= (name in (Compile, doc), version in (Compile, doc)) map DefaultOptions.scaladoc,
-      //javacOptions in Compile ++= Seq("-source", "1.7", "-target", "1.7", "-Xlint:unchecked", "-Xlint:deprecation", "-Xlint:-options"),
+      javacOptions in Compile ++= Seq("-source", "1.7", "-target", "1.7", "-Xlint:unchecked", "-Xlint:deprecation", "-Xlint:-options"),
       //scalacOptions in doc := Seq(),
       //javacOptions in doc := Seq("-source", "1.7"),
       javaOptions += "-Xmx2G",
@@ -43,7 +43,7 @@ object BuildSettings {
     compileOnly in Aspectj := true,
     verbose in Aspectj := true,
     aspectjDirectory in Aspectj <<= crossTarget,
-    sourceLevel in Aspectj := "-1.7",
+    sourceLevel in Aspectj := "-1.6",
 
     // add the compiled aspects as products
     products in Compile <++= products in Aspectj

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,7 +1,6 @@
 object BuildSettings {
   import sbt._
   import Keys._
-  import com.typesafe.sbt.SbtAspectj.{ Aspectj, aspectjSettings }
   import org.scalastyle.sbt.ScalastylePlugin
 
   lazy val buildSettings = 
@@ -37,9 +36,10 @@ object BuildSettings {
   )
 
   import com.typesafe.sbt.SbtAspectj.AspectjKeys._
-  lazy val aspectjCompileSettings = Seq(
+  import com.typesafe.sbt.SbtAspectj.{ Aspectj, aspectjSettings }
+  lazy val aspectjCompileSettings = aspectjSettings ++ Seq(
     // only compile the aspects (no weaving)
-    aspectjVersion in Aspectj := "Dependencies.aspectj_version",
+    aspectjVersion in Aspectj := Dependencies.aspectj_version,
     compileOnly in Aspectj := true,
     verbose in Aspectj := true,
     aspectjDirectory in Aspectj <<= crossTarget,

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -2,7 +2,6 @@ object BuildSettings {
   import sbt._
   import Keys._
   import com.typesafe.sbt.SbtAspectj.{ Aspectj, aspectjSettings }
-  import com.typesafe.sbt.SbtAspectj.AspectjKeys.{ compileOnly, sourceLevel, aspectjDirectory, aspectjVersion }
   import org.scalastyle.sbt.ScalastylePlugin
 
   lazy val buildSettings = 
@@ -10,6 +9,7 @@ object BuildSettings {
     sbtunidoc.Plugin.unidocSettings ++ 
     sbtunidoc.Plugin.genjavadocExtraSettings ++ 
     Publish.settings ++ 
+    aspectjCompileSettings ++
     ScalastylePlugin.Settings ++ 
     Seq(
       org.scalastyle.sbt.PluginKeys.config := file("project/scalastyle-config.xml"),
@@ -36,12 +36,14 @@ object BuildSettings {
       parallelExecution in Test := false
   )
 
-  lazy val aspectjCompileSettings = aspectjSettings ++ Seq(
+  import com.typesafe.sbt.SbtAspectj.AspectjKeys._
+  lazy val aspectjCompileSettings = Seq(
     // only compile the aspects (no weaving)
+    aspectjVersion in Aspectj := "Dependencies.aspectj_version",
     compileOnly in Aspectj := true,
+    verbose in Aspectj := true,
     aspectjDirectory in Aspectj <<= crossTarget,
-    sourceLevel in Aspectj := "-1.6",
-    aspectjVersion in Aspectj := Dependencies.aspectj_version,
+    sourceLevel in Aspectj := "-1.7",
 
     // add the compiled aspects as products
     products in Compile <++= products in Aspectj

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     ExclusionRule(organization = "org.slf4j")
   )
 
-  val aspectj_version = "1.7.3"
+  val aspectj_version = "1.7.4"
 
   val aspectj_weaver = "org.aspectj"  % "aspectjweaver" % aspectj_version
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,17 +2,7 @@ object Dependencies {
   import sbt._
   import Keys._
 
-  // to help resolve transitive problems, type:
-  //   `sbt dependency-graph`
-  //   `sbt test:dependency-tree`
-  val bad = Seq(
-    ExclusionRule(name = "log4j"),
-    ExclusionRule(name = "commons-logging"),
-    ExclusionRule(name = "commons-collections"),
-    ExclusionRule(organization = "org.slf4j")
-  )
-
-  val aspectj_version = "1.7.4"
+  val aspectj_version = "1.8.0"
 
   val aspectj_weaver = "org.aspectj"  % "aspectjweaver" % aspectj_version
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   }
 
   object play {
-    val test    = "com.typesafe.play" %% "play-test" % "2.3-SNAPSHOT"
+    val test    = "com.typesafe.play" %% "play-test" % "2.3.0"
   }
 
   object spray {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ object Dependencies {
   import sbt._
   import Keys._
 
-  val aspectj_version = "1.8.0"
+  val aspectj_version = "1.7.3"
 
   val aspectj_weaver = "org.aspectj"  % "aspectjweaver" % aspectj_version
 

--- a/project/MonitorBuild.scala
+++ b/project/MonitorBuild.scala
@@ -32,7 +32,10 @@ object MonitorBuild extends Build {
       generatedPdf in Sphinx <<= generatedPdf in Sphinx in LocalProject(docs.id) map identity,
       generatedEpub in Sphinx <<= generatedEpub in Sphinx in LocalProject(docs.id) map identity,
       // run options
-      javaOptions in run += "-javaagent:" + System.getProperty("user.home") + s"/.ivy2/cache/org.aspectj/aspectjweaver/jars/aspectjweaver-$aspectj_version.jar",
+      javaOptions in run ++= Seq(
+        "-javaagent:" + System.getProperty("user.home") + s"/.ivy2/cache/org.aspectj/aspectjweaver/jars/aspectjweaver-$aspectj_version.jar",
+        "-XX:+ExtendedDTraceProbes"
+      ),
       fork in run := true,
       connectInput in run := true,
       mainClass in (Compile, run) := Some("org.eigengo.monitor.example.akka.Main")),

--- a/project/MonitorBuild.scala
+++ b/project/MonitorBuild.scala
@@ -36,7 +36,7 @@ object MonitorBuild extends Build {
       fork in run := true,
       connectInput in run := true,
       mainClass in (Compile, run) := Some("org.eigengo.monitor.example.akka.Main")),
-    aggregate = Seq(agent, output, output_statsd, output_codahalemetrics, agent_akka, agent_spray, agent_play, example_akka, docs)) dependsOn (example_akka)
+    aggregate = Seq(agent, output, output_statsd, output_codahalemetrics, output_dtrace, agent_akka, agent_spray, agent_play, example_akka, docs)) dependsOn (example_akka)
 
 /*
   lazy val macros = module("macros") settings(
@@ -68,6 +68,8 @@ object MonitorBuild extends Build {
     libraryDependencies += akka.actor,
     libraryDependencies += specs2 % "test"
   )
+  lazy val output_dtrace = module("output-dtrace") dependsOn (output) settings (
+  )
   lazy val test = module("test") dependsOn (output) settings (
   	libraryDependencies += specs2,
     libraryDependencies += akka.testkit
@@ -91,10 +93,10 @@ object MonitorBuild extends Build {
   )
   lazy val agent_spray  = module("agent-spray")  dependsOn(agent, output)
 
-  lazy val example_akka = module("example-akka") dependsOn(agent_akka, output_statsd) settings (
+  lazy val example_akka = module("example-akka") dependsOn(agent_akka, output_statsd, output_dtrace) settings (
     libraryDependencies += akka.actor
   )
-  lazy val example_spray = module("example-spray") dependsOn(agent_spray, output_statsd) settings (
+  lazy val example_spray = module("example-spray") dependsOn(agent_spray, output_statsd, output_dtrace) settings (
     libraryDependencies += spray.can,
     libraryDependencies += spray.httpx
   )

--- a/project/MonitorBuild.scala
+++ b/project/MonitorBuild.scala
@@ -72,6 +72,7 @@ object MonitorBuild extends Build {
     libraryDependencies += specs2 % "test"
   )
   lazy val output_dtrace = module("output-dtrace") dependsOn (output) settings (
+    javaOptions in run ++= Seq("-XX:+ExtendedDTraceProbes")
   )
   lazy val test = module("test") dependsOn (output) settings (
   	libraryDependencies += specs2,

--- a/project/MonitorBuild.scala
+++ b/project/MonitorBuild.scala
@@ -1,5 +1,7 @@
 import sbt._
-import Keys._
+import sbt.Keys._
+import sbt.LocalProject
+import scala.Some
 
 object MonitorBuild extends Build {
 
@@ -72,7 +74,9 @@ object MonitorBuild extends Build {
     libraryDependencies += specs2 % "test"
   )
   lazy val output_dtrace = module("output-dtrace") dependsOn (output) settings (
-    javaOptions in run ++= Seq("-XX:+ExtendedDTraceProbes")
+    javaOptions in run ++= Seq("-XX:+ExtendedDTraceProbes"),
+    fork in run := true,
+    connectInput in run := true
   )
   lazy val test = module("test") dependsOn (output) settings (
   	libraryDependencies += specs2,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.9.5-SNAPSHOT")
+addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.9.4")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.9.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.9.5-SNAPSHOT")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.9.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.9.4")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
 


### PR DESCRIPTION
We can now submit dtrace probes (on supported JVMs, tested on Solaris 11)
