### PR TITLE
Update aspectj to compile with jdk8

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ object Dependencies {
   import sbt._
   import Keys._
 
-  val aspectj_version = "1.7.3"
+  val aspectj_version = "1.8.2"
 
   val aspectj_weaver = "org.aspectj"  % "aspectjweaver" % aspectj_version
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.9.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.10.1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
 


### PR DESCRIPTION
Tried to upgrade to be usable with java8 and scala 2.11. Got it to compile with java8. Getting it to cross compile to scala 2.11 stopped at unidoc, which uses a old version of genjavadoc which is not published for 2.11.
